### PR TITLE
Fix: Correct publication date for deprecations.info article

### DIFF
--- a/content/deprecations-info-git-scraper.md
+++ b/content/deprecations-info-git-scraper.md
@@ -1,5 +1,5 @@
 Title: Tracking AI Model Deprecations with Git Scraping: Introducing deprecations.info
-Date: 2025-01-24 10:00
+Date: 2024-08-24 14:00
 Category: data-engineering
 Tags: git-scraper, rss, automation, ai, monitoring
 Slug: deprecations-info-git-scraper


### PR DESCRIPTION
## Summary
Fixes the publication date of the deprecations.info article to August 24, 2024 so it appears as the latest article on the site.

## Changes
- Updated date from 2025-01-24 to 2024-08-24 (correct current date)

## Why this matters
The incorrect future date (2025) was preventing the article from appearing as the most recent post on the homepage.