### PR TITLE
Add current projects to projects page

### DIFF
--- a/pages/projects.html
+++ b/pages/projects.html
@@ -168,7 +168,7 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
     <h1 id="projects">Projects</h1>
   </header>
   <div>
-<p>Here's a short list of projects I've undertaken in the past.</p>
+<p>Here's a short list of projects I've undertaken, past and present.</p>
 <h2>pi-fusion</h2>
 <p><a href="https://github.com/leblancfg/pi-fusion">Open source project</a> that runs a panel of models in parallel for coding-agent tasks, then synthesizes their answers into one response.</p>
 <blockquote>

--- a/pages/projects.html
+++ b/pages/projects.html
@@ -169,8 +169,13 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
   </header>
   <div>
 <p>Here's a short list of projects I've undertaken in the past.</p>
+<h2>pi-fusion</h2>
+<p><a href="https://github.com/leblancfg/pi-fusion">Open source project</a> that runs a panel of models in parallel for coding-agent tasks, then synthesizes their answers into one response.</p>
+<blockquote>
+<p>Visit the <a href="https://leblancfg.com/pi-fusion/">website here</a>.</p>
+</blockquote>
 <h2>deprecations.info</h2>
-<p><a href="https://github.com/leblancfg/deprecations-rss">Open source project</a> that tracks AI model deprecations across major providers (OpenAI, Anthropic, Google, AWS, Cohere) using Simon Willison's git scraper pattern. Provides an RSS feed for programmatic consumption, enabling automated notifications and CI/CD integration to prevent service disruptions from deprecated models.</p>
+<p><a href="https://github.com/deprecations/deprecations-rss">Open source project</a> that tracks AI model deprecations across major providers and publishes an RSS feed for automation, monitoring, and release planning.</p>
 <blockquote>
 <p>Visit the <a href="https://deprecations.info">website here</a>.</p>
 </blockquote>


### PR DESCRIPTION
## Summary
- add pi-fusion to the projects page with GitHub and project links
- update deprecations.info to link to the deprecations/deprecations-rss repository
- tighten the project copy to match the existing page style

## Verification
- inspected pages/projects.html diff
- confirmed the requested project URLs are present
- no build command found in this generated static-site checkout