### PR TITLE
fix: use root-relative image links

### DIFF
--- a/addicted-to-my-power-meter/index.html
+++ b/addicted-to-my-power-meter/index.html
@@ -112,7 +112,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>
@@ -187,7 +187,7 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
   <div>
     <p>This winter I picked up a smart trainer for indoor cycling. I had gotten a slump in motivation from CrossFit, which I'd been doing semi-seriously for about 5 years. I loaded up Zwift, clipped in, and within a week I was hooked. Not on the virtual scenery or the gamification, but on the numbers. Specifically, the power numbers.</p>
 <p>I've been doing CrossFit for about five years now, and one of the core ideas in CrossFit is deceptively elegant: the fittest athlete is the one who maximizes the area under their power curve across all types of movement. I know, it's a moutful. But it's literally one of founder Greg Glassman's "definition of fitness".</p>
-<p><img alt="Fitness spectrum" src="img/power_curve.png"></p>
+<p><img alt="Fitness spectrum" src="/img/power_curve.png"></p>
 <p>Sprinting, lifting, gymnastics — it doesn't matter. Fitness, in this framework, is the ability to produce high power output across every time domain and every modality. So when I suddenly had access to a real-time wattage readout on the bike, something clicked. This was a language I already spoke. It's that goddamned power curve, clear as day!</p>
 <h2>The jarring return to the road</h2>
 <p>Then the snow melted.</p>
@@ -202,14 +202,14 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
 <p>This whole power obsession has sent me down a rabbit hole of analytics tools, and two in particular have fundamentally changed how I understand cycling performance.</p>
 <h3>Xert</h3>
 <p>The first is <a href="https://www.xertonline.com/">Xert</a>. You can tell there's years of slow build, trial-and-error, and working with top-rate experts on this site. Its UX is quite clunky, and newcomers get lost. Hell, I still do. But IMO it's the gold standard for any sports-specific training apps out there that I know of. User-tailored workouts and multi-week training plans, Garmin apps to monitor your metrics while on the road, and its projected fitness signatures months out are all basically unheard of anywhere else.</p>
-<p><img alt="Xert power curve" src="img/xert-power-curve.png"></p>
+<p><img alt="Xert power curve" src="/img/xert-power-curve.png"></p>
 <p>Xert builds what they call a "fitness signature" from your ride data — essentially an estimated power curve. But the really clever bit is a metric I haven't seen anywhere else: Maximum Power Available, or MPA.</p>
-<p><img alt="MPA curve" src="img/xert-mpa.png"></p>
+<p><img alt="MPA curve" src="/img/xert-mpa.png"></p>
 <p>There's a lot of hand-waving here, but you can think of MPA as your gas tank (purple line above). Your body has multiple metabolic pathways: ATP, glycogen, lactate, and so on, but you can abstract all of that into a single "battery", or "gas tank". During a ride, you're draining this battery, and your body is replenishing it at some rate. The fitter you are, the bigger the battery and the faster it refills.</p>
 <p>Xert overlays this MPA curve on top of your workout data, and it works like an inverted ceiling. When the MPA line drops down and touches your actual power output, that's failure. Your body literally cannot sustain that output anymore. Push 700 watts for 20 seconds, and if that depletes your MPA at that duration, then at the 21st second you have to back off. You won't drop to zero — maybe you can hold 500 watts for a couple more seconds — but you're drawing down a finite reserve.</p>
 <h3>Best Bike Split</h3>
 <p>The second tool is <a href="https://www.bestbikesplit.com/">Best Bike Split</a>. Given a course profile  —  say, up the mountain and back  —  it calculates your optimal power strategy. The insight is that wind resistance scales dramatically with speed, so above about 30 km/h you're mostly fighting the air. The optimal strategy is to save energy on descents, push close to threshold on flats, and spend your reserves on climbs.</p>
-<p><img alt="Best Bike Split" src="img/bbs.png"></p>
+<p><img alt="Best Bike Split" src="/img/bbs.png"></p>
 <p>Where it gets interesting to me: Best Bike Split uses a fairly simplistic model for pacing your effort. But Xert's MPA model is a much richer representation of how your body actually depletes and recovers energy. If you could overlay Xert's MPA model onto Best Bike Split's course optimization, I think you'd get meaningfully better pacing strategies. That feels like a project worth exploring. Someday.</p>
 <h2>The CrossFit connection</h2>
 <p>And this brings me back to CrossFit, because the same principle applies to every single movement in the gym. A thruster? That's just moving a known weight through a known distance in a known time — you can calculate the wattage directly. Pull-ups, same idea. Even double-unders, which are harder to measure directly, have a fairly fixed cadence that you could estimate power from.</p>

--- a/archives.html
+++ b/archives.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/author/francois-leblanc.html
+++ b/author/francois-leblanc.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/author/francois-leblanc2.html
+++ b/author/francois-leblanc2.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/author/francois-leblanc3.html
+++ b/author/francois-leblanc3.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/authors.html
+++ b/authors.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/automating-command-execution-across-tmux-panes/index.html
+++ b/automating-command-execution-across-tmux-panes/index.html
@@ -109,7 +109,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/benchmarks_writing_pandas_dataframe_SQL_Server/index.html
+++ b/benchmarks_writing_pandas_dataframe_SQL_Server/index.html
@@ -108,7 +108,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/categories.html
+++ b/categories.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/cli-ai.html
+++ b/category/cli-ai.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/cli-unix.html
+++ b/category/cli-unix.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/crossfit-python.html
+++ b/category/crossfit-python.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/data-engineering.html
+++ b/category/data-engineering.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/fitness.html
+++ b/category/fitness.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/linux.html
+++ b/category/linux.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/physics.html
+++ b/category/physics.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/python-sql-ms.html
+++ b/category/python-sql-ms.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/python.html
+++ b/category/python.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/rust.html
+++ b/category/rust.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/tmux.html
+++ b/category/tmux.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/category/vim.html
+++ b/category/vim.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/crossfit_open_2019_analysis_athlete_statistics/index.html
+++ b/crossfit_open_2019_analysis_athlete_statistics/index.html
@@ -110,7 +110,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/crossfit_open_2019_analysis_benchmark_workouts/index.html
+++ b/crossfit_open_2019_analysis_benchmark_workouts/index.html
@@ -110,7 +110,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/crossfit_open_2019_analysis_exercise_statistics/index.html
+++ b/crossfit_open_2019_analysis_exercise_statistics/index.html
@@ -110,7 +110,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/data-bus-pattern-for-data-engineering/index.html
+++ b/data-bus-pattern-for-data-engineering/index.html
@@ -109,7 +109,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/deprecations-info-git-scraper/index.html
+++ b/deprecations-info-git-scraper/index.html
@@ -111,7 +111,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/first-steps-with-rust/index.html
+++ b/first-steps-with-rust/index.html
@@ -109,7 +109,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/getting-started-with-python-and-jupyter-notebooks-1/index.html
+++ b/getting-started-with-python-and-jupyter-notebooks-1/index.html
@@ -114,7 +114,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/getting-started-with-python-and-jupyter-notebooks-2/index.html
+++ b/getting-started-with-python-and-jupyter-notebooks-2/index.html
@@ -114,7 +114,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/higher-level-functions-python-filter/index.html
+++ b/higher-level-functions-python-filter/index.html
@@ -111,7 +111,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>
@@ -1304,7 +1304,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
  .highlight pre  .il { color: #666 } /* Literal.Number.Integer.Long */</style><div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p><img src="img/filter.png" width="200" align="right">
+<p><img src="/img/filter.png" width="200" align="right">
 Python provides a few higher order (or functional programming) functions in the standard library that can be quite useful:</p>
 <ul>
 <li>map</li>

--- a/higher-level-functions-python-map/index.html
+++ b/higher-level-functions-python-map/index.html
@@ -111,7 +111,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>
@@ -1304,7 +1304,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
  .highlight pre  .il { color: #666 } /* Literal.Number.Integer.Long */</style><div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p><img src="img/map_function.png" width="200" align="right">
+<p><img src="/img/map_function.png" width="200" align="right">
 Python provides a few higher order (or functional programming) functions in the standard library that can be quite useful:</p>
 <ul>
 <li>map</li>

--- a/higher-level-functions-python-reduce/index.html
+++ b/higher-level-functions-python-reduce/index.html
@@ -111,7 +111,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>
@@ -1304,7 +1304,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
  .highlight pre  .il { color: #666 } /* Literal.Number.Integer.Long */</style><div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p><img src="img/reduce_function.png" width="200" align="right">
+<p><img src="/img/reduce_function.png" width="200" align="right">
 Python provides a few higher order (or functional programming) functions in the standard library that can be quite useful:</p>
 <ul>
 <li>map</li>
@@ -2883,7 +2883,7 @@ reduce(...)
 <li>The number of functions to apply in the chain are high enough to become unreadable, or</li>
 <li>You won't know in advance which functions to apply, and need a way to abstract it away.</li>
 </ol>
-<center><img title="Genetic Algorithm" src="img/genetic_algo.svg" width="400">
+<center><img title="Genetic Algorithm" src="/img/genetic_algo.svg" width="400">
 <i><b>Genetic Algorithms</b><br>Courtesy of [CoalHMM Documentation](https://github.com/birc-aeh/coalhmm)</i></center><p>One example of this last case that comes to mind is if you were running a genetic algorithm experiment to evolve a solution to a problem that uses function composition.</p>
 <p>For more on this, I highly recommend you take a look at Mathieu Larose's article entitled <em><a href="https://mathieularose.com/function-composition-in-python/">Function Composition in Python</a></em></p>
 

--- a/i-miss-vim/index.html
+++ b/i-miss-vim/index.html
@@ -108,7 +108,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/index2.html
+++ b/index2.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/index3.html
+++ b/index3.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/installing-azure-cli-on-manjaro-arch-with-anaconda/index.html
+++ b/installing-azure-cli-on-manjaro-arch-with-anaconda/index.html
@@ -111,7 +111,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/installing-cuda-cudnn-tensorflow-nvidia-gtx960/index.html
+++ b/installing-cuda-cudnn-tensorflow-nvidia-gtx960/index.html
@@ -114,7 +114,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/intensity-pad/index.html
+++ b/intensity-pad/index.html
@@ -110,7 +110,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>
@@ -258,7 +258,7 @@ showed live data. I then set out on building prototype pad #2 with the sensor I'
 <p>I started week three testing out that new pad, with days of noisy calibration I couldn't make heads
 or tails of. The sensor I picked from the initial shortlist failed intermittently... probably
 because I hadn't soldered it properly. But by then, it was potted in epoxy! No soup for you.</p>
-<p><img alt="A month of hardware reality: parts, tools, and prototype mess on the workbench" src="img/intensity_messy.jpeg"></p>
+<p><img alt="A month of hardware reality: parts, tools, and prototype mess on the workbench" src="/img/intensity_messy.jpeg"></p>
 <p>That third week was basically a write-off. Every few hours, reality deleted part of my mental model
 and handed me back a worse-looking, more accurate one.</p>
 <div style="margin: 1.5rem auto; max-width: 360px; width: 100%;">
@@ -284,7 +284,7 @@ dataset. I started off thinking I'd need a secondary hit detector system and add
 model. But after a couple days, I reversed course: it's perfectly acceptable that athletes get lower
 numbers if they don't hit the sweet spot. In fact, that might even be a good thing: it encourages
 better technique and accuracy.</p>
-<p><img alt="First calibration run: strike power starting to look like a real signal" src="img/calibration_analysis.png"></p>
+<p><img alt="First calibration run: strike power starting to look like a real signal" src="/img/calibration_analysis.png"></p>
 <p>From there, I was able to share with friends and reached out to a couple athletes, who hopefully
 become my first batch of beta testers.</p>
 <h2>What I actually believe now</h2>

--- a/level-up-your-command-line-skills-the-secret-to-being-a-good-unix-neighbour/index.html
+++ b/level-up-your-command-line-skills-the-secret-to-being-a-good-unix-neighbour/index.html
@@ -116,7 +116,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/pages/about/index.html
+++ b/pages/about/index.html
@@ -101,7 +101,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -101,7 +101,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/pi-fusion-local-inference-time-scaling-for-coding-agents/index.html
+++ b/pi-fusion-local-inference-time-scaling-for-coding-agents/index.html
@@ -114,7 +114,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>
@@ -200,7 +200,7 @@ exactly what got handed to the main agent.</p>
 <p>So I built <a href="https://github.com/leblancfg/pi-fusion">an extension for <code>pi-coding-agent</code> called
 <code>pi-fusion</code></a> that recreates it, plus a few more bells and
 whistles.</p>
-<p><img alt="pi-fusion: several models in parallel, one synthesized answer" src="img/pi_fusion_social_preview.png"></p>
+<p><img alt="pi-fusion: several models in parallel, one synthesized answer" src="/img/pi_fusion_social_preview.png"></p>
 <p>It runs a local planning panel before the normal actor turn. It can load shared context, split your
 prompt into a few angles, run independent worker agents in parallel, and write their notes into the
 actor's first turn.</p>
@@ -240,7 +240,7 @@ version I could run locally in the terminal and modify when the defaults were wr
 </ol>
 <p>Discovery and rewrite are optional. Worker count is configurable. The synthesis model can be the
 same model you're already using in <code>pi</code>, or a different one.</p>
-<p><img alt="pi-fusion running in the pi TUI" src="img/pi_fusion_demo.gif"></p>
+<p><img alt="pi-fusion running in the pi TUI" src="/img/pi_fusion_demo.gif"></p>
 <p>A fused turn adds latency. On the setup I use most often, it's roughly eight to ten seconds before
 the actor starts. I don't want that for typo fixes. I do want it when I'm asking for a bug hunt, a
 refactor plan, or a review of code I don't know well.</p>

--- a/surge-cycling-up-a-hill/index.html
+++ b/surge-cycling-up-a-hill/index.html
@@ -110,7 +110,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>
@@ -183,7 +183,7 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
 
 
   <div>
-    <p><img alt="Cycling uphill" src="img/12_percent_hill.jpg"></p>
+    <p><img alt="Cycling uphill" src="/img/12_percent_hill.jpg"></p>
 <h2>The Physics of Cycling Uphill</h2>
 <p>My wife and I recently upgraded from our late 80s steel bikes to more modern ones, and purchased an erg-enabled indoor trainer. I've been spending a surprising number of hours on Zwift, and turns out... it's great fun! I consider myself an all-round athlete, so it was to my great dismay to discover that what I thought was being in OK shape is &mdash; as far as comparison with other indoor cyclists goes &mdash; relatively poor performance! This of course, was very exciting. I love a good training challenge.</p>
 <p>I've participated in a few races and noticed many different strategies being used when tackling hills. Having tried various approaches myself, I could definitely feel that some were much better than others. But was that due to luck and good timing on my part, or actually a good strategy? The good news is, cycling is mostly "basic" physics, and we can simulate it!</p>

--- a/tag/agents.html
+++ b/tag/agents.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/ai.html
+++ b/tag/ai.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/anaconda.html
+++ b/tag/anaconda.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/arch.html
+++ b/tag/arch.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/athlete.html
+++ b/tag/athlete.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/automation.html
+++ b/tag/automation.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/azure.html
+++ b/tag/azure.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/bash.html
+++ b/tag/bash.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/beginner.html
+++ b/tag/beginner.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/benchmarks.html
+++ b/tag/benchmarks.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/bookmarks.html
+++ b/tag/bookmarks.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/chartjs.html
+++ b/tag/chartjs.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/cli.html
+++ b/tag/cli.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/click.html
+++ b/tag/click.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/command-line.html
+++ b/tag/command-line.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/conda.html
+++ b/tag/conda.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/crossfit.html
+++ b/tag/crossfit.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/cuda.html
+++ b/tag/cuda.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/cudnn.html
+++ b/tag/cudnn.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/cycling.html
+++ b/tag/cycling.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/data-bus.html
+++ b/tag/data-bus.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/data-engineering.html
+++ b/tag/data-engineering.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/data.html
+++ b/tag/data.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/durable-execution.html
+++ b/tag/durable-execution.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/engineering.html
+++ b/tag/engineering.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/etl.html
+++ b/tag/etl.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/fitness.html
+++ b/tag/fitness.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/functional.html
+++ b/tag/functional.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/geopandas.html
+++ b/tag/geopandas.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/git-scraper.html
+++ b/tag/git-scraper.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/gpu.html
+++ b/tag/gpu.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/gtx960.html
+++ b/tag/gtx960.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/hardware.html
+++ b/tag/hardware.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/intensity.html
+++ b/tag/intensity.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/jupyter.html
+++ b/tag/jupyter.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/learning.html
+++ b/tag/learning.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/linux.html
+++ b/tag/linux.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/llms.html
+++ b/tag/llms.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/manjaro.html
+++ b/tag/manjaro.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/matplotlib.html
+++ b/tag/matplotlib.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/monitoring.html
+++ b/tag/monitoring.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/mutability.html
+++ b/tag/mutability.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/neovim.html
+++ b/tag/neovim.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/nerdtree.html
+++ b/tag/nerdtree.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/numpy.html
+++ b/tag/numpy.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/nvidia.html
+++ b/tag/nvidia.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/physics.html
+++ b/tag/physics.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/pi.html
+++ b/tag/pi.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/postgresql.html
+++ b/tag/postgresql.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/power.html
+++ b/tag/power.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/productivity.html
+++ b/tag/productivity.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/programming.html
+++ b/tag/programming.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/prototype.html
+++ b/tag/prototype.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/python.html
+++ b/tag/python.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/python2.html
+++ b/tag/python2.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/rss.html
+++ b/tag/rss.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/rust.html
+++ b/tag/rust.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/scipy.html
+++ b/tag/scipy.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/shapely.html
+++ b/tag/shapely.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/shell.html
+++ b/tag/shell.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/simulation.html
+++ b/tag/simulation.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/sql-server.html
+++ b/tag/sql-server.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/summary-statistics.html
+++ b/tag/summary-statistics.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/tensorflow.html
+++ b/tag/tensorflow.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/terminal.html
+++ b/tag/terminal.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/test-time-compute.html
+++ b/tag/test-time-compute.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/tmux.html
+++ b/tag/tmux.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/unix.html
+++ b/tag/unix.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/vim.html
+++ b/tag/vim.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/xert.html
+++ b/tag/xert.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/zsh.html
+++ b/tag/zsh.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tag/zwift.html
+++ b/tag/zwift.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/tags.html
+++ b/tags.html
@@ -99,7 +99,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>

--- a/til-nerdtree-bookmarks/index.html
+++ b/til-nerdtree-bookmarks/index.html
@@ -109,7 +109,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>
@@ -189,7 +189,7 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
 <p>The following commands are only accessible when your cursor is in a NERDTree pane. If you're not seeing the command show up, this might be why.</p>
 <p>To create a new bookmark, simply navigate to the directory you want to save in NERDTree, and press <code>:Bookmark</code> to assign a shortcut to that bookmark. For example, to save a bookmark in the <code>tests/</code> folder, place your cursor on top, press <code>:Bookmark</code>, and you will then be able to see this new bookmark within your NERDTree pane.</p>
 <p>By default there is no shortcut assigned to the bookmark, but a simple <code>:Bo&lt;Tab&gt;</code> should suffice.</p>
-<p><img alt="Screenshot of NERDTree bookmark called &quot;output&quot;" src="img/NERDTree_bookmark.png"></p>
+<p><img alt="Screenshot of NERDTree bookmark called &quot;output&quot;" src="/img/NERDTree_bookmark.png"></p>
 <h1>Jumping to an Existing Bookmark</h1>
 <p>To jump to an existing bookmark, you'll need to use the <code>:OpenBookmark &lt;BOOKMARK&gt;</code> command. Again, using tab completion typing e.g. <code>:OpenBookmark output</code> ends up being a quick <code>:Op&lt;Tab&gt; o&lt;Tab&gt;</code>. Try it for yourself!</p>
 <h1>Listing and Editing Bookmarks</h1>

--- a/trying-absurd-postgres-workflows/index.html
+++ b/trying-absurd-postgres-workflows/index.html
@@ -110,7 +110,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>
@@ -189,7 +189,7 @@ creator of <a href="https://flask.palletsprojects.com/">Flask</a>,
 <a href="https://jinja.palletsprojects.com/">Jinja</a>, and <a href="https://rye.astral.sh/">Rye</a>). It's
 explicitly not production-ready, but I wanted to see what kind of niche it might fill.
 My test case: AI workloads with expensive LLM API calls.</p>
-<p><img src="img/absurd_screenshot.gif" alt="Absurd Workflows Screenshot" width="500"
+<p><img src="/img/absurd_screenshot.gif" alt="Absurd Workflows Screenshot" width="500"
 style="display:block; margin:auto;"></p>
 <p>→ <strong>Jump into the demo app</strong>: <a href="https://absurd.leblancfg.com">absurd.leblancfg.com</a></p>
 <p>→ <strong>Source code for the demo app</strong>: <code><a href="https://github.com/leblancfg/absurd-test">leblancfg/absurd-test</a></code></p>

--- a/unhashable-python-unique-locations-geometry-geodataframe/index.html
+++ b/unhashable-python-unique-locations-geometry-geodataframe/index.html
@@ -110,7 +110,7 @@
             </li>
 
           <li>
-            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >Résumé</a>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
           </li>
       </ul>
     </nav>


### PR DESCRIPTION
## Summary

- Change generated article image references from relative `img/...` to root-relative `/img/...`.
- Rename the sidebar link text from `Résumé` to `CV` across generated pages.

## Investigation

The site now serves article pages at extensionless directory-style routes, for example:

- `https://leblancfg.com/pi-fusion-local-inference-time-scaling-for-coding-agents/`

On those routes, an image reference like `src="img/pi_fusion_social_preview.png"` resolves to:

- `https://leblancfg.com/pi-fusion-local-inference-time-scaling-for-coding-agents/img/pi_fusion_social_preview.png`

That path 404s. The asset itself exists at:

- `https://leblancfg.com/img/pi_fusion_social_preview.png`

Using `/img/...` makes the references independent of whether the page is served as `.html` or as an extensionless directory route.

## Validation

- Confirmed the reported URL returns `404` while `/img/pi_fusion_social_preview.png` returns `200`.
- Verified there are no remaining `src="img/` or `href="img/` references in generated HTML.
- Verified all `/img/...` targets referenced by generated HTML exist locally.
- Ran `git diff --check`.
