### PR TITLE
Add CrossFit Open dataset artifact

### DIFF
--- a/archives.html
+++ b/archives.html
@@ -167,6 +167,11 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
   <div>
     <dl>
 
+          <dt>July 02, 2026</dt>
+
+        <dd>
+          <a href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">Building a 2026 CrossFit Open Athlete Dataset</a>
+        </dd>
           <dt>June 14, 2026</dt>
 
         <dd>

--- a/category/fitness.html
+++ b/category/fitness.html
@@ -164,6 +164,25 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
 
 <article>
   <header>
+    <h2><a href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">Building a 2026 CrossFit Open Athlete Dataset</a></h2>
+    <p>
+      Posted on July 02, 2026 in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>
+
+
+    </p>
+  </header>
+  <div>
+      <div><p>A public SQLite artifact and checkpointed scraper for analyzing the 2026 CrossFit Open Men 35-39 leaderboard.</p></div>
+        <br>
+        <a class="btn"
+           href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">
+          Continue reading
+        </a>
+  </div>
+  <hr />
+</article>
+<article>
+  <header>
     <h2><a href="https://leblancfg.com/intensity-pad">I Spent My Sabbatical Building a Power Meter for Sledgehammers</a></h2>
     <p>
       Posted on April 17, 2026 in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>

--- a/crossfit-open-2026-athlete-dataset/index.html
+++ b/crossfit-open-2026-athlete-dataset/index.html
@@ -1,0 +1,324 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="HandheldFriendly" content="True" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="index, follow" />
+
+  <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,400;0,700;1,400&family=Source+Sans+Pro:ital,wght@0,300;0,400;0,700;1,400&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" type="text/css" href="https://leblancfg.com/theme/stylesheet/style.min.css">
+
+
+    <link id="pygments-light-theme" rel="stylesheet" type="text/css"
+          href="https://leblancfg.com/theme/pygments/monokai.min.css">
+
+
+
+  <link rel="stylesheet" type="text/css" href="https://leblancfg.com/theme/font-awesome/css/fontawesome.css">
+  <link rel="stylesheet" type="text/css" href="https://leblancfg.com/theme/font-awesome/css/brands.css">
+  <link rel="stylesheet" type="text/css" href="https://leblancfg.com/theme/font-awesome/css/solid.css">
+
+
+  <link rel="shortcut icon" href="/img/icons/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/img/icons/favicon.ico" type="image/x-icon">
+
+  <!-- Chrome, Firefox OS and Opera -->
+  <meta name="theme-color" content="#330033">
+  <!-- Windows Phone -->
+  <meta name="msapplication-navbutton-color" content="#330033">
+  <!-- iOS Safari -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <!-- Microsoft EDGE -->
+  <meta name="msapplication-TileColor" content="#330033">
+
+  <link href="https://leblancfg.com/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="leblancfg.com Atom">
+
+  <link href="https://leblancfg.com/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="leblancfg.com RSS">
+
+<script type="text/javascript">
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-120300361-1', 'auto');
+  ga('send', 'pageview');
+</script>
+
+
+
+<meta name="author" content="François Leblanc" />
+<meta name="description" content="A public SQLite artifact and checkpointed scraper for analyzing the 2026 CrossFit Open Men 35-39 leaderboard." />
+<meta name="keywords" content="crossfit, fitness, data, athlete">
+
+
+  <meta property="og:site_name" content="leblancfg.com"/>
+  <meta property="og:title" content="Building a 2026 CrossFit Open Athlete Dataset"/>
+  <meta property="og:description" content="A public SQLite artifact and checkpointed scraper for analyzing the 2026 CrossFit Open Men 35-39 leaderboard."/>
+  <meta property="og:locale" content="en_US"/>
+  <meta property="og:url" content="https://leblancfg.com/crossfit-open-2026-athlete-dataset"/>
+  <meta property="og:type" content="article"/>
+  <meta property="article:published_time" content="2026-07-02 00:00:00-04:00"/>
+  <meta property="article:modified_time" content=""/>
+  <meta property="article:author" content="https://leblancfg.com/author/francois-leblanc.html">
+  <meta property="article:section" content="Fitness"/>
+  <meta property="article:tag" content="crossfit"/>
+  <meta property="article:tag" content="fitness"/>
+  <meta property="article:tag" content="data"/>
+  <meta property="article:tag" content="athlete"/>
+  <meta property="og:image" content="https://avatars0.githubusercontent.com/u/15659410?s=400&u=e3bc92486becb34e77028eef0f4dfc302540fcb3&v=4">
+
+  <title>leblancfg.com &ndash; Building a 2026 CrossFit Open Athlete Dataset</title>
+
+
+</head>
+<body class="light-theme">
+
+<aside>
+  <div>
+    <a href="https://leblancfg.com/">
+      <img src="https://avatars0.githubusercontent.com/u/15659410?s=400&u=e3bc92486becb34e77028eef0f4dfc302540fcb3&v=4" alt="François Leblanc" title="François Leblanc">
+    </a>
+
+    <h1>
+      <a href="https://leblancfg.com/">François Leblanc</a>
+    </h1>
+
+    <p>Data Science, Geospatial Python, Space Stuff</p>
+
+
+    <nav>
+      <ul class="list">
+
+
+            <li>
+              <a target="_self"
+                 href="https://leblancfg.com/pages/about">
+                About
+              </a>
+            </li>
+            <li>
+              <a target="_self"
+                 href="https://leblancfg.com/pages/projects">
+                Projects
+              </a>
+            </li>
+
+          <li>
+            <a target="_self" href="https://leblancfg.com/pages/leblancfg_CV.pdf" >CV</a>
+          </li>
+      </ul>
+    </nav>
+
+    <ul class="social">
+      <li>
+        <a class="sc-linkedin"
+           href="https://www.linkedin.com/in/fran%C3%A7ois-leblanc-07294b106/"
+           target="_blank">
+          <i class="fa-brands fa-linkedin"></i>
+        </a>
+      </li>
+      <li>
+        <a class="sc-github"
+           href="https://github.com/leblancfg"
+           target="_blank">
+          <i class="fa-brands fa-github"></i>
+        </a>
+      </li>
+      <li>
+        <a class="sc-mastodon"
+rel="me"           href="https://hachyderm.io/@leblancfg"
+           target="_blank">
+          <i class="fa-brands fa-mastodon"></i>
+        </a>
+      </li>
+      <li>
+        <a class="sc-x"
+           href="https://x.com/leblanc_fg"
+           target="_blank">
+          <svg class="x-logo" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path>
+          </svg>
+        </a>
+      </li>
+      <li>
+        <a class="sc-rss"
+           href="https://leblancfg.com/feeds/all.atom.xml"
+           target="_blank">
+          <i class="fa-solid fa-rss"></i>
+        </a>
+      </li>
+    </ul>
+  </div>
+
+</aside>
+  <main>
+
+<nav>
+  <a href="https://leblancfg.com/">Home</a>
+
+  <a href="/archives.html">Archives</a>
+  <a href="/categories.html">Categories</a>
+  <a href="/tags.html">Tags</a>
+
+  <a href="https://leblancfg.com/feeds/all.atom.xml">Atom</a>
+
+  <a href="https://leblancfg.com/feeds/all.rss.xml">RSS</a>
+</nav>
+
+<article class="single">
+  <header>
+
+    <h1 id="crossfit-open-2026-athlete-dataset">Building a 2026 CrossFit Open Athlete Dataset</h1>
+    <p>
+      Posted on July 02, 2026 in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>
+
+    </p>
+  </header>
+
+
+  <div>
+    <p>I’m competing in the 2027 CrossFit Open in Men 35-39. If the target is 90th percentile worldwide,
+the first useful question is brutally concrete: what does that mean in leaderboard terms?</p>
+
+<p>So I built the beginning of the dataset I wanted to read: a restartable public scrape of the
+CrossFit Games leaderboard API, stored as SQLite, with raw source responses kept beside normalized
+tables. The first complete artifact covers the full 2026 Men 35-39 Open division: <strong>29,171
+athletes</strong>, <strong>87,513 workout-score rows</strong>, and the API’s published
+<strong>29,171</strong> competitor field lining up with the normalized row count.</p>
+
+<p><a class="btn" href="/data/crossfit-open/crossfit_open_2026.sqlite">Download the SQLite artifact</a>
+<a class="btn" href="/data/crossfit-open/README.md">Read the data dictionary</a>
+<a class="btn" href="/data/crossfit-open/summary.json">Open summary JSON</a></p>
+
+<h2>The 90th percentile target</h2>
+<p>CrossFit’s current athlete pages did not expose an Open percentile field in the public HTML I checked.
+The dataset derives percentile from rank and field size instead. In Men 35-39 for 2026, the 90th
+percentile cutoff lands at <strong>rank 2,918</strong> out of
+<strong>29,171</strong>. In plain English: top ten percent meant being inside the
+first <strong>2,918</strong> athletes worldwide.</p>
+
+<p><img alt="Bar chart of Men 35-39 athletes by performance percentile bucket" src="/data/crossfit-open/men-35-39-percentile-buckets.svg"></p>
+
+<p>The athlete at exactly rank 2,918 had an overall score of 11,119. His workout ranks were 6,427,
+1,395, and 3,297. That is useful because it keeps the goal from collapsing into a vague identity
+claim. A 90th percentile Open does not require being elite at everything, but it does require
+surviving one weaker event without letting the total score drift out of range.</p>
+
+<h2>Where the field comes from</h2>
+<p>The field is large enough that country mix matters. The United States dominates the division, but
+Canada still contributes <strong>960</strong> athletes. The first full scrape found
+these top countries:</p>
+
+<ul>
+<li><strong>US</strong>: 9,817 athletes (United States)</li>
+<li><strong>FR</strong>: 2,670 athletes (France)</li>
+<li><strong>GB</strong>: 2,428 athletes (United Kingdom)</li>
+<li><strong>BR</strong>: 1,389 athletes (Brazil)</li>
+<li><strong>AU</strong>: 1,264 athletes (Australia)</li>
+<li><strong>KR</strong>: 1,124 athletes (Korea (the Republic of))</li>
+<li><strong>CA</strong>: 960 athletes (Canada)</li>
+<li><strong>IT</strong>: 843 athletes (Italy)</li>
+</ul>
+
+<p><img alt="Bar chart of top countries in the 2026 Open Men 35-39 division" src="/data/crossfit-open/men-35-39-top-countries.svg"></p>
+
+<h2>What is in the database</h2>
+<p>The SQLite file includes normalized tables for divisions, athletes, leaderboard entries, workout
+scores, and source fetches. Keeping <code>source_fetches</code> makes the database bigger, but I think it is the
+right tradeoff for a public artifact: readers can inspect exactly what came back from the public API,
+and the scraper can resume without hammering pages it already fetched successfully.</p>
+
+<p>The profile-page path is implemented too, but deliberately sampled rather than fully run. Athlete
+pages are much heavier than leaderboard API pages. The artifact includes <strong>25</strong>
+profile fetches and <strong>165</strong> parsed benchmark values to prove
+the parser, while leaving the full profile crawl as an explicit long-running job.</p>
+
+<h2>Useful starter queries</h2>
+<p>Find the 90th percentile boundary:</p>
+<pre><code>select max(overall_rank) as rank_cutoff, count(*) as athletes
+from leaderboard_entries
+where year = 2026
+  and competition_type = 'open'
+  and division_id = 18
+  and performance_percentile &gt;= 90;</code></pre>
+
+<p>Look at the event-rank spread for top-10-percent athletes:</p>
+<pre><code>select ordinal, min(rank) as best_rank, max(rank) as worst_rank
+from workout_scores ws
+join leaderboard_entries le
+  using (year, competition_type, division_id, competitor_id)
+where le.year = 2026
+  and le.competition_type = 'open'
+  and le.division_id = 18
+  and le.performance_percentile &gt;= 90
+group by ordinal
+order by ordinal;</code></pre>
+
+<ul>
+<li>Workout 1: top-10-percent athlete workout ranks span 1 to 8,585.</li>
+<li>Workout 2: top-10-percent athlete workout ranks span 1 to 9,903.</li>
+<li>Workout 3: top-10-percent athlete workout ranks span 2 to 7,358.</li>
+</ul>
+
+<h2>Provenance and next step</h2>
+<p>Preflight happened on July 2, 2026. The CrossFit robots file allowed the leaderboard and public
+athlete pages, while disallowing registration, score submission, and athlete-management paths. The
+leaderboard page points at the public <code>c3po.crossfit.com</code> leaderboard API. Athlete pages still expose
+rank tables and self-reported benchmark stats, but I did not find a public Open percentile field.</p>
+
+<p>The full all-division scrape is now a command, not a wish:</p>
+<pre><code>python3 scripts/crossfit_open_dataset.py \
+  --db data/crossfit-open/crossfit_open_2026.sqlite \
+  scrape-leaderboard --division all --sleep 1.0</code></pre>
+
+<p>Generated summary timestamp: <code>2026-07-02 23:18:01 UTC</code>.</p>
+  </div>
+  <div class="tag-cloud">
+    <p>
+      <a href="https://leblancfg.com/tag/crossfit.html">crossfit</a>
+<a href="https://leblancfg.com/tag/fitness.html">fitness</a>
+<a href="https://leblancfg.com/tag/data.html">data</a>
+<a href="https://leblancfg.com/tag/athlete.html">athlete</a>
+    </p>
+  </div>
+
+
+</article>
+
+<footer>
+<p>
+  &copy; 2026  - This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/deed.en_US" target="_blank">Creative Commons Attribution-ShareAlike</a>
+</p>
+<p>
+Built with <a href="http://getpelican.com" target="_blank">Pelican</a> using <a href="http://bit.ly/flex-pelican" target="_blank">Flex</a> theme
+</p><p>
+  <a rel="license"
+     href="http://creativecommons.org/licenses/by-sa/4.0/"
+     target="_blank">
+    <img alt="Creative Commons License"
+         title="Creative Commons License"
+         style="border-width:0"
+           src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"
+         width="80"
+         height="15"/>
+  </a>
+</p></footer>  </main>
+
+<script type="application/ld+json">
+{
+  "@context" : "http://schema.org",
+  "@type" : "Blog",
+  "name": " leblancfg.com ",
+  "url" : "https://leblancfg.com",
+  "image": "https://avatars0.githubusercontent.com/u/15659410?s=400&u=e3bc92486becb34e77028eef0f4dfc302540fcb3&v=4",
+  "description": "François Leblanc's Thoughts and Writings"
+}
+</script>
+</body>
+</html>

--- a/data/crossfit-open/README.md
+++ b/data/crossfit-open/README.md
@@ -1,0 +1,67 @@
+# CrossFit Open Dataset Artifact
+
+This folder contains a reproducible SQLite artifact built from public CrossFit Games leaderboard pages and APIs.
+
+Current checked-in artifact:
+
+- `crossfit_open_2026.sqlite`
+- full 2026 Open Men 35-39 leaderboard: 29,171 athletes
+- full 2026 Open Men 35-39 workout scores: 87,513 rows
+- discovered page and competitor counts for 23 known 2026 Open divisions
+- top-25 Men 35-39 public athlete profile sample for benchmark-stat parsing
+
+The scraper is intentionally checkpointed and polite:
+
+- raw successful responses are stored in `source_fetches`
+- normalized leaderboard rows are stored in `leaderboard_entries`, `athletes`, and `workout_scores`
+- re-running the same command skips already-successful fetches unless `--refresh` is passed
+- the default delay is one second per leaderboard page and three seconds per athlete profile page
+
+Robots check on July 2, 2026: `https://games.crossfit.com/robots.txt` disallowed `/register/open`, `/submit-scores`, and `/manage-competition/athlete`; the leaderboard and public athlete pages were allowed.
+
+## Build
+
+From the repository root:
+
+```bash
+python3 scripts/crossfit_open_dataset.py --db data/crossfit-open/crossfit_open_2026.sqlite discover --sleep 1.0
+python3 scripts/crossfit_open_dataset.py --db data/crossfit-open/crossfit_open_2026.sqlite scrape-leaderboard --division 18 --sleep 1.0
+python3 scripts/crossfit_open_dataset.py --db data/crossfit-open/crossfit_open_2026.sqlite scrape-profiles --division 18 --limit 25 --sleep 3.0
+python3 scripts/crossfit_open_dataset.py --db data/crossfit-open/crossfit_open_2026.sqlite write-summary-assets --out-dir data/crossfit-open
+```
+
+To continue toward all known 2026 Open divisions:
+
+```bash
+python3 scripts/crossfit_open_dataset.py --db data/crossfit-open/crossfit_open_2026.sqlite scrape-leaderboard --division all --sleep 1.0
+```
+
+## Tables
+
+- `metadata`: source and schema metadata.
+- `source_fetches`: raw checkpointed HTTP responses, keyed by source type, year, division/page, or athlete id.
+- `divisions`: discovered division names, categories, page counts, and competitor counts.
+- `athletes`: athlete profile fields exposed in leaderboard rows.
+- `leaderboard_entries`: one row per athlete per division, including rank fraction and rank-derived `performance_percentile`.
+- `workout_scores`: one row per athlete per Open workout.
+- `athlete_open_ranks`: optional profile-page rank history parsed from public athlete pages.
+- `benchmark_stats`: optional self-reported benchmark values parsed from public athlete pages.
+
+## Percentile Definition
+
+CrossFit athlete pages did not expose an Open percentile field during the July 2, 2026 preflight. The dataset therefore derives:
+
+```text
+performance_percentile = 100 * (1 - ((overall_rank - 1) / (total_competitors - 1)))
+```
+
+The top-ranked athlete is 100.0. The last-ranked athlete approaches 0.0. A 90th percentile athlete is inside approximately the top 10 percent of their division.
+
+## Provenance
+
+- Leaderboard HTML page inspected: `https://games.crossfit.com/leaderboard/open/2026?division=18&sort=0`
+- Leaderboard API used: `https://c3po.crossfit.com/api/leaderboards/v2/competitions/open/2026/leaderboards?division=18&sort=0&page=1`
+- Athlete page sample inspected: `https://games.crossfit.com/athlete/911088`
+- Robots file inspected: `https://games.crossfit.com/robots.txt`
+
+This is an independent research artifact. CrossFit is a trademark of CrossFit LLC; the source data remains owned by its respective publisher.

--- a/data/crossfit-open/men-35-39-percentile-buckets.svg
+++ b/data/crossfit-open/men-35-39-percentile-buckets.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="360" viewBox="0 0 760 360" role="img" aria-labelledby="title desc">
+<title>2026 Open Men 35-39 by performance percentile</title>
+<desc>Horizontal bar chart generated from the local SQLite artifact.</desc>
+<rect width="100%" height="100%" fill="#f8f8f8"/>
+<text x="120" y="30" font-family="Source Sans Pro, Arial, sans-serif" font-size="22" font-weight="700" fill="#222">2026 Open Men 35-39 by performance percentile</text>
+<text x="108" y="78.4" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">99-100</text>
+<rect x="120" y="58.0" width="24.7" height="30.0" fill="#330033"/>
+<text x="152.7" y="78.4" font-family="Source Code Pro, monospace" font-size="13" fill="#333">292</text>
+<text x="108" y="118.4" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">95-99</text>
+<rect x="120" y="98.0" width="98.7" height="30.0" fill="#330033"/>
+<text x="226.7" y="118.4" font-family="Source Code Pro, monospace" font-size="13" fill="#333">1,168</text>
+<text x="108" y="158.4" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">90-95</text>
+<rect x="120" y="138.0" width="123.1" height="30.0" fill="#330033"/>
+<text x="251.1" y="158.4" font-family="Source Code Pro, monospace" font-size="13" fill="#333">1,458</text>
+<text x="108" y="198.4" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">75-90</text>
+<rect x="120" y="178.0" width="369.5" height="30.0" fill="#330033"/>
+<text x="497.5" y="198.4" font-family="Source Code Pro, monospace" font-size="13" fill="#333">4,375</text>
+<text x="108" y="238.4" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">50-75</text>
+<rect x="120" y="218.0" width="616.0" height="30.0" fill="#330033"/>
+<text x="744.0" y="238.4" font-family="Source Code Pro, monospace" font-size="13" fill="#333">7,293</text>
+<text x="108" y="278.4" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">25-50</text>
+<rect x="120" y="258.0" width="615.9" height="30.0" fill="#330033"/>
+<text x="743.9" y="278.4" font-family="Source Code Pro, monospace" font-size="13" fill="#333">7,292</text>
+<text x="108" y="318.4" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">0-25</text>
+<rect x="120" y="298.0" width="616.0" height="30.0" fill="#330033"/>
+<text x="744.0" y="318.4" font-family="Source Code Pro, monospace" font-size="13" fill="#333">7,293</text>
+</svg>

--- a/data/crossfit-open/men-35-39-top-countries.svg
+++ b/data/crossfit-open/men-35-39-top-countries.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="420" viewBox="0 0 760 420" role="img" aria-labelledby="title desc">
+<title>Top countries in Men 35-39</title>
+<desc>Horizontal bar chart generated from the local SQLite artifact.</desc>
+<rect width="100%" height="100%" fill="#f8f8f8"/>
+<text x="120" y="30" font-family="Source Sans Pro, Arial, sans-serif" font-size="22" font-weight="700" fill="#222">Top countries in Men 35-39</text>
+<text x="108" y="70.5" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">US</text>
+<rect x="120" y="58.0" width="616.0" height="18.3" fill="#330033"/>
+<text x="744.0" y="70.5" font-family="Source Code Pro, monospace" font-size="13" fill="#333">9,817</text>
+<text x="108" y="98.8" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">FR</text>
+<rect x="120" y="86.3" width="167.5" height="18.3" fill="#330033"/>
+<text x="295.5" y="98.8" font-family="Source Code Pro, monospace" font-size="13" fill="#333">2,670</text>
+<text x="108" y="127.1" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">GB</text>
+<rect x="120" y="114.7" width="152.4" height="18.3" fill="#330033"/>
+<text x="280.4" y="127.1" font-family="Source Code Pro, monospace" font-size="13" fill="#333">2,428</text>
+<text x="108" y="155.5" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">BR</text>
+<rect x="120" y="143.0" width="87.2" height="18.3" fill="#330033"/>
+<text x="215.2" y="155.5" font-family="Source Code Pro, monospace" font-size="13" fill="#333">1,389</text>
+<text x="108" y="183.8" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">AU</text>
+<rect x="120" y="171.3" width="79.3" height="18.3" fill="#330033"/>
+<text x="207.3" y="183.8" font-family="Source Code Pro, monospace" font-size="13" fill="#333">1,264</text>
+<text x="108" y="212.1" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">KR</text>
+<rect x="120" y="199.7" width="70.5" height="18.3" fill="#330033"/>
+<text x="198.5" y="212.1" font-family="Source Code Pro, monospace" font-size="13" fill="#333">1,124</text>
+<text x="108" y="240.5" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">CA</text>
+<rect x="120" y="228.0" width="60.2" height="18.3" fill="#330033"/>
+<text x="188.2" y="240.5" font-family="Source Code Pro, monospace" font-size="13" fill="#333">960</text>
+<text x="108" y="268.8" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">IT</text>
+<rect x="120" y="256.3" width="52.9" height="18.3" fill="#330033"/>
+<text x="180.9" y="268.8" font-family="Source Code Pro, monospace" font-size="13" fill="#333">843</text>
+<text x="108" y="297.1" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">ES</text>
+<rect x="120" y="284.7" width="42.8" height="18.3" fill="#330033"/>
+<text x="170.8" y="297.1" font-family="Source Code Pro, monospace" font-size="13" fill="#333">682</text>
+<text x="108" y="325.5" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">DE</text>
+<rect x="120" y="313.0" width="41.7" height="18.3" fill="#330033"/>
+<text x="169.7" y="325.5" font-family="Source Code Pro, monospace" font-size="13" fill="#333">665</text>
+<text x="108" y="353.8" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">NL</text>
+<rect x="120" y="341.3" width="36.1" height="18.3" fill="#330033"/>
+<text x="164.1" y="353.8" font-family="Source Code Pro, monospace" font-size="13" fill="#333">575</text>
+<text x="108" y="382.1" text-anchor="end" font-family="Source Code Pro, monospace" font-size="13" fill="#333">ZA</text>
+<rect x="120" y="369.7" width="34.0" height="18.3" fill="#330033"/>
+<text x="162.0" y="382.1" font-family="Source Code Pro, monospace" font-size="13" fill="#333">542</text>
+</svg>

--- a/data/crossfit-open/summary.json
+++ b/data/crossfit-open/summary.json
@@ -1,0 +1,416 @@
+{
+  "generated_at": "2026-07-02T23:18:01+00:00",
+  "source": {
+    "leaderboard_api": "https://c3po.crossfit.com/api/leaderboards/v2/competitions/open/2026/leaderboards",
+    "games_robots": "https://games.crossfit.com/robots.txt",
+    "athlete_page_example": "https://games.crossfit.com/athlete/911088"
+  },
+  "divisions": [
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 1,
+      "division_name": "Men",
+      "category": "individual",
+      "gender": "M",
+      "total_pages": 2543,
+      "total_competitors": 127113,
+      "discovered_at": "2026-07-02T23:00:17+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 2,
+      "division_name": "Women",
+      "category": "individual",
+      "gender": "F",
+      "total_pages": 2120,
+      "total_competitors": 105959,
+      "discovered_at": "2026-07-02T23:00:18+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 3,
+      "division_name": "Men 45-49",
+      "category": "age_group",
+      "gender": "M",
+      "total_pages": 294,
+      "total_competitors": 14691,
+      "discovered_at": "2026-07-02T23:00:20+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 4,
+      "division_name": "Women 45-49",
+      "category": "age_group",
+      "gender": "F",
+      "total_pages": 225,
+      "total_competitors": 11248,
+      "discovered_at": "2026-07-02T23:00:21+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 5,
+      "division_name": "Men 50-54",
+      "category": "age_group",
+      "gender": "M",
+      "total_pages": 170,
+      "total_competitors": 8486,
+      "discovered_at": "2026-07-02T23:00:22+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 6,
+      "division_name": "Women 50-54",
+      "category": "age_group",
+      "gender": "F",
+      "total_pages": 122,
+      "total_competitors": 6051,
+      "discovered_at": "2026-07-02T23:00:23+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 7,
+      "division_name": "Men 55-59",
+      "category": "age_group",
+      "gender": "M",
+      "total_pages": 108,
+      "total_competitors": 5397,
+      "discovered_at": "2026-07-02T23:00:25+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 8,
+      "division_name": "Women 55-59",
+      "category": "age_group",
+      "gender": "F",
+      "total_pages": 83,
+      "total_competitors": 4143,
+      "discovered_at": "2026-07-02T23:00:26+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 11,
+      "division_name": "Teams",
+      "category": "team",
+      "gender": "",
+      "total_pages": 13,
+      "total_competitors": 640,
+      "discovered_at": "2026-07-02T23:00:27+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 12,
+      "division_name": "Men 40-44",
+      "category": "age_group",
+      "gender": "M",
+      "total_pages": 440,
+      "total_competitors": 21970,
+      "discovered_at": "2026-07-02T23:00:29+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 13,
+      "division_name": "Women 40-44",
+      "category": "age_group",
+      "gender": "F",
+      "total_pages": 346,
+      "total_competitors": 17264,
+      "discovered_at": "2026-07-02T23:00:30+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 14,
+      "division_name": "Boys 14-15",
+      "category": "teen",
+      "gender": "M",
+      "total_pages": 22,
+      "total_competitors": 1077,
+      "discovered_at": "2026-07-02T23:00:31+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 15,
+      "division_name": "Girls 14-15",
+      "category": "teen",
+      "gender": "F",
+      "total_pages": 21,
+      "total_competitors": 1049,
+      "discovered_at": "2026-07-02T23:00:33+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 16,
+      "division_name": "Boys 16-17",
+      "category": "teen",
+      "gender": "M",
+      "total_pages": 24,
+      "total_competitors": 1195,
+      "discovered_at": "2026-07-02T23:00:34+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 17,
+      "division_name": "Girls 16-17",
+      "category": "teen",
+      "gender": "F",
+      "total_pages": 23,
+      "total_competitors": 1108,
+      "discovered_at": "2026-07-02T23:00:36+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 18,
+      "division_name": "Men 35-39",
+      "category": "age_group",
+      "gender": "M",
+      "total_pages": 584,
+      "total_competitors": 29171,
+      "discovered_at": "2026-07-02T23:15:50+00:00",
+      "scraped_entries": 29171
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 19,
+      "division_name": "Women 35-39",
+      "category": "age_group",
+      "gender": "F",
+      "total_pages": 454,
+      "total_competitors": 22673,
+      "discovered_at": "2026-07-02T23:00:38+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 36,
+      "division_name": "Men 60-64",
+      "category": "age_group",
+      "gender": "M",
+      "total_pages": 57,
+      "total_competitors": 2825,
+      "discovered_at": "2026-07-02T23:00:40+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 37,
+      "division_name": "Women 60-64",
+      "category": "age_group",
+      "gender": "F",
+      "total_pages": 47,
+      "total_competitors": 2325,
+      "discovered_at": "2026-07-02T23:00:41+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 40,
+      "division_name": "Men 65-69",
+      "category": "age_group",
+      "gender": "M",
+      "total_pages": 27,
+      "total_competitors": 1329,
+      "discovered_at": "2026-07-02T23:00:42+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 41,
+      "division_name": "Women 65-69",
+      "category": "age_group",
+      "gender": "F",
+      "total_pages": 25,
+      "total_competitors": 1230,
+      "discovered_at": "2026-07-02T23:00:43+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 42,
+      "division_name": "Men 70+",
+      "category": "age_group",
+      "gender": "M",
+      "total_pages": 15,
+      "total_competitors": 740,
+      "discovered_at": "2026-07-02T23:00:44+00:00",
+      "scraped_entries": 0
+    },
+    {
+      "year": 2026,
+      "competition_type": "open",
+      "division_id": 43,
+      "division_name": "Women 70+",
+      "category": "age_group",
+      "gender": "F",
+      "total_pages": 15,
+      "total_competitors": 739,
+      "discovered_at": "2026-07-02T23:00:46+00:00",
+      "scraped_entries": 0
+    }
+  ],
+  "men_35_39": {
+    "entries": 29171,
+    "best_rank": 1,
+    "worst_rank": 27117,
+    "avg_age": 36.902163107195506,
+    "canada_entries": 960,
+    "us_entries": 9817
+  },
+  "men_35_39_90th_percentile_cutoff": {
+    "min_rank": 1,
+    "max_rank": 2918,
+    "athletes": 2918
+  },
+  "men_35_39_percentile_buckets": [
+    {
+      "bucket": "99-100",
+      "athletes": 292
+    },
+    {
+      "bucket": "95-99",
+      "athletes": 1168
+    },
+    {
+      "bucket": "90-95",
+      "athletes": 1458
+    },
+    {
+      "bucket": "75-90",
+      "athletes": 4375
+    },
+    {
+      "bucket": "50-75",
+      "athletes": 7293
+    },
+    {
+      "bucket": "25-50",
+      "athletes": 7292
+    },
+    {
+      "bucket": "0-25",
+      "athletes": 7293
+    }
+  ],
+  "men_35_39_top_countries": [
+    {
+      "country_code": "US",
+      "country_name": "United States",
+      "athletes": 9817
+    },
+    {
+      "country_code": "FR",
+      "country_name": "France",
+      "athletes": 2670
+    },
+    {
+      "country_code": "GB",
+      "country_name": "United Kingdom",
+      "athletes": 2428
+    },
+    {
+      "country_code": "BR",
+      "country_name": "Brazil",
+      "athletes": 1389
+    },
+    {
+      "country_code": "AU",
+      "country_name": "Australia",
+      "athletes": 1264
+    },
+    {
+      "country_code": "KR",
+      "country_name": "Korea (the Republic of)",
+      "athletes": 1124
+    },
+    {
+      "country_code": "CA",
+      "country_name": "Canada",
+      "athletes": 960
+    },
+    {
+      "country_code": "IT",
+      "country_name": "Italy",
+      "athletes": 843
+    },
+    {
+      "country_code": "ES",
+      "country_name": "Spain",
+      "athletes": 682
+    },
+    {
+      "country_code": "DE",
+      "country_name": "Germany",
+      "athletes": 665
+    },
+    {
+      "country_code": "NL",
+      "country_name": "Netherlands",
+      "athletes": 575
+    },
+    {
+      "country_code": "ZA",
+      "country_name": "South Africa",
+      "athletes": 542
+    }
+  ],
+  "men_35_39_top_10_percent_workout_rank_ranges": [
+    {
+      "ordinal": 1,
+      "workout_label": "1",
+      "best_rank": 1,
+      "worst_rank": 8585
+    },
+    {
+      "ordinal": 2,
+      "workout_label": "2",
+      "best_rank": 1,
+      "worst_rank": 9903
+    },
+    {
+      "ordinal": 3,
+      "workout_label": "3",
+      "best_rank": 2,
+      "worst_rank": 7358
+    }
+  ],
+  "profile_counts": {
+    "fetched_profiles": 25,
+    "athletes_with_benchmarks": 17,
+    "benchmark_values": 165
+  }
+}

--- a/index.html
+++ b/index.html
@@ -164,6 +164,25 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
 
 <article>
   <header>
+    <h2><a href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">Building a 2026 CrossFit Open Athlete Dataset</a></h2>
+    <p>
+      Posted on July 02, 2026 in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>
+
+
+    </p>
+  </header>
+  <div>
+      <div><p>A public SQLite artifact and checkpointed scraper for analyzing the 2026 CrossFit Open Men 35-39 leaderboard.</p></div>
+        <br>
+        <a class="btn"
+           href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">
+          Continue reading
+        </a>
+  </div>
+  <hr />
+</article>
+<article>
+  <header>
     <h2><a href="https://leblancfg.com/pi-fusion-local-inference-time-scaling-for-coding-agents">pi-fusion: Local inference-time scaling for coding agents</a></h2>
     <p>
       Posted on June 14, 2026 in <a href="https://leblancfg.com/category/cli-ai.html">cli, ai</a>

--- a/scripts/crossfit_open_dataset.py
+++ b/scripts/crossfit_open_dataset.py
@@ -1,0 +1,1053 @@
+#!/usr/bin/env python3
+"""Build a checkpointed SQLite dataset from public CrossFit Open leaderboards.
+
+The CrossFit Games site currently renders leaderboards from the public
+`c3po.crossfit.com` API. This script keeps the original API responses in
+SQLite, normalizes the competition rows, and can resume without refetching
+successful pages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import html
+import json
+import re
+import sqlite3
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_DB = Path("data/crossfit-open/crossfit_open_2026.sqlite")
+USER_AGENT = "leblancfg.com CrossFit Open research dataset (contact: https://leblancfg.com)"
+LEADERBOARD_URL = (
+    "https://c3po.crossfit.com/api/leaderboards/v2/competitions/"
+    "{competition_type}/{year}/leaderboards?division={division_id}&sort={sort}&page={page}"
+)
+ATHLETE_URL = "https://games.crossfit.com/athlete/{competitor_id}"
+
+
+DIVISIONS_2026: dict[int, dict[str, str]] = {
+    1: {"name": "Men", "category": "individual", "gender": "M"},
+    2: {"name": "Women", "category": "individual", "gender": "F"},
+    3: {"name": "Men 45-49", "category": "age_group", "gender": "M"},
+    4: {"name": "Women 45-49", "category": "age_group", "gender": "F"},
+    5: {"name": "Men 50-54", "category": "age_group", "gender": "M"},
+    6: {"name": "Women 50-54", "category": "age_group", "gender": "F"},
+    7: {"name": "Men 55-59", "category": "age_group", "gender": "M"},
+    8: {"name": "Women 55-59", "category": "age_group", "gender": "F"},
+    11: {"name": "Teams", "category": "team", "gender": ""},
+    12: {"name": "Men 40-44", "category": "age_group", "gender": "M"},
+    13: {"name": "Women 40-44", "category": "age_group", "gender": "F"},
+    14: {"name": "Boys 14-15", "category": "teen", "gender": "M"},
+    15: {"name": "Girls 14-15", "category": "teen", "gender": "F"},
+    16: {"name": "Boys 16-17", "category": "teen", "gender": "M"},
+    17: {"name": "Girls 16-17", "category": "teen", "gender": "F"},
+    18: {"name": "Men 35-39", "category": "age_group", "gender": "M"},
+    19: {"name": "Women 35-39", "category": "age_group", "gender": "F"},
+    36: {"name": "Men 60-64", "category": "age_group", "gender": "M"},
+    37: {"name": "Women 60-64", "category": "age_group", "gender": "F"},
+    40: {"name": "Men 65-69", "category": "age_group", "gender": "M"},
+    41: {"name": "Women 65-69", "category": "age_group", "gender": "F"},
+    42: {"name": "Men 70+", "category": "age_group", "gender": "M"},
+    43: {"name": "Women 70+", "category": "age_group", "gender": "F"},
+}
+
+
+SCHEMA = """
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS source_fetches (
+  source_type TEXT NOT NULL,
+  year INTEGER NOT NULL,
+  competition_type TEXT NOT NULL,
+  division_id INTEGER NOT NULL DEFAULT -1,
+  page INTEGER NOT NULL DEFAULT -1,
+  competitor_id TEXT NOT NULL DEFAULT '',
+  url TEXT NOT NULL,
+  fetched_at TEXT NOT NULL,
+  http_status INTEGER NOT NULL,
+  sha256 TEXT,
+  body TEXT,
+  error TEXT,
+  PRIMARY KEY (source_type, year, competition_type, division_id, page, competitor_id)
+) WITHOUT ROWID;
+
+CREATE TABLE IF NOT EXISTS divisions (
+  year INTEGER NOT NULL,
+  competition_type TEXT NOT NULL,
+  division_id INTEGER NOT NULL,
+  division_name TEXT NOT NULL,
+  category TEXT NOT NULL,
+  gender TEXT,
+  total_pages INTEGER,
+  total_competitors INTEGER,
+  discovered_at TEXT NOT NULL,
+  PRIMARY KEY (year, competition_type, division_id)
+);
+
+CREATE TABLE IF NOT EXISTS athletes (
+  competitor_id TEXT PRIMARY KEY,
+  competitor_name TEXT,
+  first_name TEXT,
+  last_name TEXT,
+  gender TEXT,
+  country_code TEXT,
+  country_name TEXT,
+  region_id TEXT,
+  region_name TEXT,
+  affiliate_id TEXT,
+  affiliate_name TEXT,
+  age INTEGER,
+  height_raw TEXT,
+  weight_raw TEXT,
+  profile_pic_s3_key TEXT,
+  status TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS leaderboard_entries (
+  year INTEGER NOT NULL,
+  competition_type TEXT NOT NULL,
+  division_id INTEGER NOT NULL,
+  competitor_id TEXT NOT NULL,
+  overall_rank INTEGER,
+  overall_rank_raw TEXT,
+  overall_score TEXT,
+  rank_fraction REAL,
+  performance_percentile REAL,
+  next_stage TEXT,
+  scaled INTEGER,
+  source_page INTEGER NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (year, competition_type, division_id, competitor_id)
+);
+
+CREATE TABLE IF NOT EXISTS workout_scores (
+  year INTEGER NOT NULL,
+  competition_type TEXT NOT NULL,
+  division_id INTEGER NOT NULL,
+  competitor_id TEXT NOT NULL,
+  ordinal INTEGER NOT NULL,
+  workout_label TEXT,
+  rank INTEGER,
+  rank_raw TEXT,
+  score_raw TEXT,
+  score_display TEXT,
+  valid TEXT,
+  scaled INTEGER,
+  video INTEGER,
+  judge TEXT,
+  affiliate TEXT,
+  time_seconds INTEGER,
+  breakdown TEXT,
+  score_identifier TEXT,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (year, competition_type, division_id, competitor_id, ordinal)
+);
+
+CREATE TABLE IF NOT EXISTS athlete_open_ranks (
+  competitor_id TEXT NOT NULL,
+  year INTEGER NOT NULL,
+  scope TEXT NOT NULL,
+  division_name TEXT NOT NULL DEFAULT '',
+  rank_raw TEXT,
+  rank INTEGER,
+  url TEXT,
+  parsed_at TEXT NOT NULL,
+  PRIMARY KEY (competitor_id, year, scope, division_name)
+) WITHOUT ROWID;
+
+CREATE TABLE IF NOT EXISTS benchmark_stats (
+  competitor_id TEXT NOT NULL,
+  stat_name TEXT NOT NULL,
+  raw_value TEXT NOT NULL,
+  numeric_value REAL,
+  unit TEXT,
+  parsed_at TEXT NOT NULL,
+  PRIMARY KEY (competitor_id, stat_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_leaderboard_division_rank
+  ON leaderboard_entries (year, competition_type, division_id, overall_rank);
+CREATE INDEX IF NOT EXISTS idx_scores_workout_rank
+  ON workout_scores (year, competition_type, division_id, ordinal, rank);
+CREATE INDEX IF NOT EXISTS idx_athletes_country
+  ON athletes (country_code, region_name);
+"""
+
+
+def utcnow() -> str:
+    return dt.datetime.now(dt.UTC).isoformat(timespec="seconds")
+
+
+def connect(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA)
+    set_metadata(con, "schema_version", "1")
+    set_metadata(con, "generated_by", "scripts/crossfit_open_dataset.py")
+    return con
+
+
+def set_metadata(con: sqlite3.Connection, key: str, value: str) -> None:
+    con.execute(
+        """
+        INSERT INTO metadata (key, value, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at
+        """,
+        (key, value, utcnow()),
+    )
+
+
+def parse_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    match = re.search(r"\d+", str(value).replace(",", ""))
+    return int(match.group(0)) if match else None
+
+
+def parse_float_with_unit(raw_value: str) -> tuple[float | None, str | None]:
+    clean = " ".join(raw_value.split())
+    if not clean or clean == "--":
+        return None, None
+    match = re.match(r"^(-?\d+(?:\.\d+)?)(?:\s*([A-Za-z]+))?$", clean)
+    if not match:
+        return None, None
+    return float(match.group(1)), match.group(2)
+
+
+def performance_percentile(rank: int | None, total: int | None) -> float | None:
+    if not rank or not total or total < 1:
+        return None
+    if total == 1:
+        return 100.0
+    return round(100.0 * (1.0 - ((rank - 1) / (total - 1))), 4)
+
+
+def rank_fraction(rank: int | None, total: int | None) -> float | None:
+    if not rank or not total:
+        return None
+    return round(rank / total, 8)
+
+
+def fetch(
+    con: sqlite3.Connection,
+    *,
+    source_type: str,
+    year: int,
+    competition_type: str,
+    url: str,
+    division_id: int | None = None,
+    page: int | None = None,
+    competitor_id: str | None = None,
+    sleep_seconds: float = 1.0,
+    refresh: bool = False,
+) -> str:
+    division_key = division_id if division_id is not None else -1
+    page_key = page if page is not None else -1
+    competitor_key = competitor_id if competitor_id is not None else ""
+    existing = con.execute(
+        """
+        SELECT body, http_status, error
+        FROM source_fetches
+        WHERE source_type = ?
+          AND year = ?
+          AND competition_type = ?
+          AND division_id = ?
+          AND page = ?
+          AND competitor_id = ?
+        """,
+        (source_type, year, competition_type, division_key, page_key, competitor_key),
+    ).fetchone()
+    if existing and existing["http_status"] == 200 and existing["body"] and not refresh:
+        return str(existing["body"])
+
+    if sleep_seconds > 0:
+        time.sleep(sleep_seconds)
+
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, "Accept": "*/*"})
+    status = 0
+    body = ""
+    error = None
+    try:
+        with urllib.request.urlopen(request, timeout=45) as response:
+            status = int(response.status)
+            body = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        status = int(exc.code)
+        error = str(exc)
+        body = exc.read().decode("utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001 - stored for restartable diagnostics.
+        status = 0
+        error = f"{type(exc).__name__}: {exc}"
+
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest() if body else None
+    con.execute(
+        """
+        INSERT INTO source_fetches (
+          source_type, year, competition_type, division_id, page, competitor_id,
+          url, fetched_at, http_status, sha256, body, error
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT DO UPDATE SET
+          url=excluded.url,
+          fetched_at=excluded.fetched_at,
+          http_status=excluded.http_status,
+          sha256=excluded.sha256,
+          body=excluded.body,
+          error=excluded.error
+        """,
+        (
+            source_type,
+            year,
+            competition_type,
+            division_key,
+            page_key,
+            competitor_key,
+            url,
+            utcnow(),
+            status,
+            digest,
+            body,
+            error,
+        ),
+    )
+    con.commit()
+    if status != 200:
+        raise RuntimeError(f"fetch failed ({status}) for {url}: {error or body[:200]}")
+    return body
+
+
+def leaderboard_url(year: int, competition_type: str, division_id: int, page: int, sort: int) -> str:
+    return LEADERBOARD_URL.format(
+        competition_type=urllib.parse.quote(competition_type),
+        year=year,
+        division_id=division_id,
+        sort=sort,
+        page=page,
+    )
+
+
+def upsert_division(
+    con: sqlite3.Connection,
+    *,
+    year: int,
+    competition_type: str,
+    division_id: int,
+    total_pages: int | None,
+    total_competitors: int | None,
+) -> None:
+    info = DIVISIONS_2026.get(division_id, {"name": f"Division {division_id}", "category": "unknown", "gender": ""})
+    con.execute(
+        """
+        INSERT INTO divisions (
+          year, competition_type, division_id, division_name, category, gender,
+          total_pages, total_competitors, discovered_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(year, competition_type, division_id) DO UPDATE SET
+          division_name=excluded.division_name,
+          category=excluded.category,
+          gender=excluded.gender,
+          total_pages=excluded.total_pages,
+          total_competitors=excluded.total_competitors,
+          discovered_at=excluded.discovered_at
+        """,
+        (
+            year,
+            competition_type,
+            division_id,
+            info["name"],
+            info["category"],
+            info["gender"],
+            total_pages,
+            total_competitors,
+            utcnow(),
+        ),
+    )
+
+
+def normalize_leaderboard_page(
+    con: sqlite3.Connection,
+    *,
+    year: int,
+    competition_type: str,
+    division_id: int,
+    source_page: int,
+    payload: dict[str, Any],
+) -> int:
+    pagination = payload.get("pagination") or {}
+    total_competitors = parse_int(pagination.get("totalCompetitors"))
+    total_pages = parse_int(pagination.get("totalPages"))
+    upsert_division(
+        con,
+        year=year,
+        competition_type=competition_type,
+        division_id=division_id,
+        total_pages=total_pages,
+        total_competitors=total_competitors,
+    )
+    ordinals = {int(o["ordinal"]): str(o.get("columnName") or o["ordinal"]) for o in payload.get("ordinals") or []}
+    rows = payload.get("leaderboardRows") or []
+    now = utcnow()
+
+    for row in rows:
+        entrant = row.get("entrant") or {}
+        competitor_id = str(entrant.get("competitorId") or "")
+        if not competitor_id:
+            continue
+        overall_rank = parse_int(row.get("overallRank"))
+        con.execute(
+            """
+            INSERT INTO athletes (
+              competitor_id, competitor_name, first_name, last_name, gender,
+              country_code, country_name, region_id, region_name, affiliate_id,
+              affiliate_name, age, height_raw, weight_raw, profile_pic_s3_key,
+              status, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(competitor_id) DO UPDATE SET
+              competitor_name=excluded.competitor_name,
+              first_name=excluded.first_name,
+              last_name=excluded.last_name,
+              gender=excluded.gender,
+              country_code=excluded.country_code,
+              country_name=excluded.country_name,
+              region_id=excluded.region_id,
+              region_name=excluded.region_name,
+              affiliate_id=excluded.affiliate_id,
+              affiliate_name=excluded.affiliate_name,
+              age=excluded.age,
+              height_raw=excluded.height_raw,
+              weight_raw=excluded.weight_raw,
+              profile_pic_s3_key=excluded.profile_pic_s3_key,
+              status=excluded.status,
+              updated_at=excluded.updated_at
+            """,
+            (
+                competitor_id,
+                entrant.get("competitorName"),
+                entrant.get("firstName"),
+                entrant.get("lastName"),
+                entrant.get("gender"),
+                entrant.get("countryOfOriginCode"),
+                entrant.get("countryOfOriginName"),
+                entrant.get("regionId"),
+                entrant.get("regionName"),
+                entrant.get("affiliateId"),
+                entrant.get("affiliateName"),
+                parse_int(entrant.get("age")),
+                entrant.get("height"),
+                entrant.get("weight"),
+                entrant.get("profilePicS3key"),
+                entrant.get("status"),
+                now,
+            ),
+        )
+        con.execute(
+            """
+            INSERT INTO leaderboard_entries (
+              year, competition_type, division_id, competitor_id, overall_rank,
+              overall_rank_raw, overall_score, rank_fraction, performance_percentile,
+              next_stage, scaled, source_page, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(year, competition_type, division_id, competitor_id) DO UPDATE SET
+              overall_rank=excluded.overall_rank,
+              overall_rank_raw=excluded.overall_rank_raw,
+              overall_score=excluded.overall_score,
+              rank_fraction=excluded.rank_fraction,
+              performance_percentile=excluded.performance_percentile,
+              next_stage=excluded.next_stage,
+              scaled=excluded.scaled,
+              source_page=excluded.source_page,
+              updated_at=excluded.updated_at
+            """,
+            (
+                year,
+                competition_type,
+                division_id,
+                competitor_id,
+                overall_rank,
+                row.get("overallRank"),
+                row.get("overallScore"),
+                rank_fraction(overall_rank, total_competitors),
+                performance_percentile(overall_rank, total_competitors),
+                row.get("nextStage"),
+                parse_int((payload.get("competition") or {}).get("scaled")),
+                source_page,
+                now,
+            ),
+        )
+        for score in row.get("scores") or []:
+            ordinal = parse_int(score.get("ordinal"))
+            if ordinal is None:
+                continue
+            con.execute(
+                """
+                INSERT INTO workout_scores (
+                  year, competition_type, division_id, competitor_id, ordinal,
+                  workout_label, rank, rank_raw, score_raw, score_display,
+                  valid, scaled, video, judge, affiliate, time_seconds,
+                  breakdown, score_identifier, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(year, competition_type, division_id, competitor_id, ordinal) DO UPDATE SET
+                  workout_label=excluded.workout_label,
+                  rank=excluded.rank,
+                  rank_raw=excluded.rank_raw,
+                  score_raw=excluded.score_raw,
+                  score_display=excluded.score_display,
+                  valid=excluded.valid,
+                  scaled=excluded.scaled,
+                  video=excluded.video,
+                  judge=excluded.judge,
+                  affiliate=excluded.affiliate,
+                  time_seconds=excluded.time_seconds,
+                  breakdown=excluded.breakdown,
+                  score_identifier=excluded.score_identifier,
+                  updated_at=excluded.updated_at
+                """,
+                (
+                    year,
+                    competition_type,
+                    division_id,
+                    competitor_id,
+                    ordinal,
+                    ordinals.get(ordinal),
+                    parse_int(score.get("rank")),
+                    score.get("rank"),
+                    score.get("score"),
+                    score.get("scoreDisplay"),
+                    score.get("valid"),
+                    parse_int(score.get("scaled")),
+                    parse_int(score.get("video")),
+                    score.get("judge"),
+                    score.get("affiliate"),
+                    parse_int(score.get("time")),
+                    score.get("breakdown"),
+                    score.get("scoreIdentifier"),
+                    now,
+                ),
+            )
+    return len(rows)
+
+
+def scrape_leaderboard(
+    con: sqlite3.Connection,
+    *,
+    year: int,
+    competition_type: str,
+    division_id: int,
+    sort: int,
+    sleep_seconds: float,
+    max_pages: int | None,
+    refresh: bool,
+) -> None:
+    first_body = fetch(
+        con,
+        source_type="leaderboard",
+        year=year,
+        competition_type=competition_type,
+        division_id=division_id,
+        page=1,
+        url=leaderboard_url(year, competition_type, division_id, 1, sort),
+        sleep_seconds=sleep_seconds,
+        refresh=refresh,
+    )
+    first_payload = json.loads(first_body)
+    total_pages = parse_int((first_payload.get("pagination") or {}).get("totalPages")) or 0
+    target_pages = total_pages if max_pages is None else min(total_pages, max_pages)
+    rows = normalize_leaderboard_page(
+        con,
+        year=year,
+        competition_type=competition_type,
+        division_id=division_id,
+        source_page=1,
+        payload=first_payload,
+    )
+    con.commit()
+    print(f"division={division_id} page=1/{total_pages} rows={rows}")
+
+    for page in range(2, target_pages + 1):
+        body = fetch(
+            con,
+            source_type="leaderboard",
+            year=year,
+            competition_type=competition_type,
+            division_id=division_id,
+            page=page,
+            url=leaderboard_url(year, competition_type, division_id, page, sort),
+            sleep_seconds=sleep_seconds,
+            refresh=refresh,
+        )
+        payload = json.loads(body)
+        rows = normalize_leaderboard_page(
+            con,
+            year=year,
+            competition_type=competition_type,
+            division_id=division_id,
+            source_page=page,
+            payload=payload,
+        )
+        con.commit()
+        print(f"division={division_id} page={page}/{total_pages} rows={rows}")
+
+
+def discover(
+    con: sqlite3.Connection,
+    *,
+    year: int,
+    competition_type: str,
+    sleep_seconds: float,
+    refresh: bool,
+) -> None:
+    for division_id in DIVISIONS_2026:
+        body = fetch(
+            con,
+            source_type="leaderboard",
+            year=year,
+            competition_type=competition_type,
+            division_id=division_id,
+            page=1,
+            url=leaderboard_url(year, competition_type, division_id, 1, 0),
+            sleep_seconds=sleep_seconds,
+            refresh=refresh,
+        )
+        payload = json.loads(body)
+        pagination = payload.get("pagination") or {}
+        upsert_division(
+            con,
+            year=year,
+            competition_type=competition_type,
+            division_id=division_id,
+            total_pages=parse_int(pagination.get("totalPages")),
+            total_competitors=parse_int(pagination.get("totalCompetitors")),
+        )
+        con.commit()
+        info = DIVISIONS_2026[division_id]
+        print(
+            f"{division_id:>2} {info['name']:<14} "
+            f"pages={pagination.get('totalPages')} competitors={pagination.get('totalCompetitors')}"
+        )
+
+
+BENCHMARK_RE = re.compile(
+    r'<tr>\s*<th[^>]*class="[^"]*stats-header[^"]*"[^>]*>(?P<name>.*?)</th>\s*<td[^>]*>(?P<value>.*?)</td>\s*</tr>',
+    re.IGNORECASE | re.DOTALL,
+)
+OPEN_ROW_RE = re.compile(r"<tr>\s*<td[^>]*>\s*(?P<year>20\d{2})\s*</td>(?P<body>.*?)</tr>", re.DOTALL)
+RANK_LINK_RE = re.compile(
+    r'<span class="rank">(?:<a href="(?P<url>[^"]+)">)?(?P<rank>[^<]+?)(?:<small>[^<]+</small>)?(?:</a>)?</span>\s*'
+    r'<span class="division">(?P<division>[^<]+)</span>',
+    re.DOTALL,
+)
+
+
+def clean_text(fragment: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", fragment)
+    return " ".join(html.unescape(text).split())
+
+
+def parse_profile(con: sqlite3.Connection, competitor_id: str, body: str) -> None:
+    parsed_at = utcnow()
+    if "Benchmark Stats" in body:
+        benchmark_section = body.split("Benchmark Stats", 1)[1]
+        for match in BENCHMARK_RE.finditer(benchmark_section):
+            name = clean_text(match.group("name"))
+            value = clean_text(match.group("value"))
+            if not name or not value or value == "--":
+                continue
+            numeric, unit = parse_float_with_unit(value)
+            con.execute(
+                """
+                INSERT INTO benchmark_stats (
+                  competitor_id, stat_name, raw_value, numeric_value, unit, parsed_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(competitor_id, stat_name) DO UPDATE SET
+                  raw_value=excluded.raw_value,
+                  numeric_value=excluded.numeric_value,
+                  unit=excluded.unit,
+                  parsed_at=excluded.parsed_at
+                """,
+                (competitor_id, name, value, numeric, unit, parsed_at),
+            )
+
+    open_section = body.split("<h4>Open</h4>", 1)
+    if len(open_section) == 2:
+        section = open_section[1].split("</table>", 1)[0]
+        for row in OPEN_ROW_RE.finditer(section):
+            year = int(row.group("year"))
+            for idx, rank_match in enumerate(RANK_LINK_RE.finditer(row.group("body"))):
+                raw_rank = clean_text(rank_match.group("rank"))
+                division_name = clean_text(rank_match.group("division"))
+                scope = "worldwide" if idx < 2 else f"profile_scope_{idx + 1}"
+                con.execute(
+                    """
+                    INSERT INTO athlete_open_ranks (
+                      competitor_id, year, scope, division_name, rank_raw, rank, url, parsed_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT DO UPDATE SET
+                      rank_raw=excluded.rank_raw,
+                      rank=excluded.rank,
+                      url=excluded.url,
+                      parsed_at=excluded.parsed_at
+                    """,
+                    (
+                        competitor_id,
+                        year,
+                        scope,
+                        division_name,
+                        raw_rank,
+                        parse_int(raw_rank),
+                        html.unescape(rank_match.group("url") or ""),
+                        parsed_at,
+                    ),
+                )
+
+
+def scrape_profiles(
+    con: sqlite3.Connection,
+    *,
+    year: int,
+    competition_type: str,
+    division_id: int,
+    limit: int | None,
+    sleep_seconds: float,
+    refresh: bool,
+) -> None:
+    query = """
+        SELECT competitor_id
+        FROM leaderboard_entries
+        WHERE year = ? AND competition_type = ? AND division_id = ?
+        ORDER BY overall_rank IS NULL, overall_rank, competitor_id
+    """
+    params: list[Any] = [year, competition_type, division_id]
+    if limit is not None:
+        query += " LIMIT ?"
+        params.append(limit)
+    rows = con.execute(query, params).fetchall()
+    for index, row in enumerate(rows, start=1):
+        competitor_id = str(row["competitor_id"])
+        body = fetch(
+            con,
+            source_type="athlete_profile",
+            year=year,
+            competition_type=competition_type,
+            competitor_id=competitor_id,
+            url=ATHLETE_URL.format(competitor_id=competitor_id),
+            sleep_seconds=sleep_seconds,
+            refresh=refresh,
+        )
+        parse_profile(con, competitor_id, body)
+        con.commit()
+        print(f"profile {index}/{len(rows)} competitor_id={competitor_id}")
+
+
+def write_summary_assets(con: sqlite3.Connection, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    division_rows = con.execute(
+        """
+        SELECT d.*, COUNT(le.competitor_id) AS scraped_entries
+        FROM divisions d
+        LEFT JOIN leaderboard_entries le
+          ON le.year = d.year
+         AND le.competition_type = d.competition_type
+         AND le.division_id = d.division_id
+        GROUP BY d.year, d.competition_type, d.division_id
+        ORDER BY d.division_id
+        """
+    ).fetchall()
+    men_35_39 = con.execute(
+        """
+        SELECT
+          COUNT(*) AS entries,
+          MIN(overall_rank) AS best_rank,
+          MAX(overall_rank) AS worst_rank,
+          AVG(age) AS avg_age,
+          SUM(country_code = 'CA') AS canada_entries,
+          SUM(country_code = 'US') AS us_entries
+        FROM leaderboard_entries le
+        JOIN athletes a USING (competitor_id)
+        WHERE le.year = 2026 AND le.competition_type = 'open' AND le.division_id = 18
+        """
+    ).fetchone()
+    percentile_buckets = con.execute(
+        """
+        WITH bucketed AS (
+          SELECT
+            CASE
+              WHEN performance_percentile >= 99 THEN '99-100'
+              WHEN performance_percentile >= 95 THEN '95-99'
+              WHEN performance_percentile >= 90 THEN '90-95'
+              WHEN performance_percentile >= 75 THEN '75-90'
+              WHEN performance_percentile >= 50 THEN '50-75'
+              WHEN performance_percentile >= 25 THEN '25-50'
+              ELSE '0-25'
+            END AS bucket
+          FROM leaderboard_entries
+          WHERE year = 2026 AND competition_type = 'open' AND division_id = 18
+        )
+        SELECT bucket, COUNT(*) AS athletes
+        FROM bucketed
+        GROUP BY bucket
+        ORDER BY
+          CASE bucket
+            WHEN '99-100' THEN 1
+            WHEN '95-99' THEN 2
+            WHEN '90-95' THEN 3
+            WHEN '75-90' THEN 4
+            WHEN '50-75' THEN 5
+            WHEN '25-50' THEN 6
+            ELSE 7
+          END
+        """
+    ).fetchall()
+    top_countries = con.execute(
+        """
+        SELECT a.country_code, a.country_name, COUNT(*) AS athletes
+        FROM leaderboard_entries le
+        JOIN athletes a USING (competitor_id)
+        WHERE le.year = 2026 AND le.competition_type = 'open' AND le.division_id = 18
+        GROUP BY a.country_code, a.country_name
+        ORDER BY athletes DESC, a.country_name
+        LIMIT 12
+        """
+    ).fetchall()
+    top_90_cutoff = con.execute(
+        """
+        SELECT MIN(overall_rank) AS min_rank, MAX(overall_rank) AS max_rank, COUNT(*) AS athletes
+        FROM leaderboard_entries
+        WHERE year = 2026
+          AND competition_type = 'open'
+          AND division_id = 18
+          AND performance_percentile >= 90
+        """
+    ).fetchone()
+    score_cutoffs = con.execute(
+        """
+        SELECT ordinal, workout_label, MIN(rank) AS best_rank, MAX(rank) AS worst_rank
+        FROM workout_scores ws
+        JOIN leaderboard_entries le
+          ON le.year = ws.year
+         AND le.competition_type = ws.competition_type
+         AND le.division_id = ws.division_id
+         AND le.competitor_id = ws.competitor_id
+        WHERE le.year = 2026
+          AND le.competition_type = 'open'
+          AND le.division_id = 18
+          AND le.performance_percentile >= 90
+        GROUP BY ordinal, workout_label
+        ORDER BY ordinal
+        """
+    ).fetchall()
+    profile_counts = con.execute(
+        """
+        SELECT
+          (SELECT COUNT(*) FROM source_fetches WHERE source_type = 'athlete_profile' AND http_status = 200) AS fetched_profiles,
+          (SELECT COUNT(DISTINCT competitor_id) FROM benchmark_stats) AS athletes_with_benchmarks,
+          (SELECT COUNT(*) FROM benchmark_stats) AS benchmark_values
+        """
+    ).fetchone()
+    summary = {
+        "generated_at": utcnow(),
+        "source": {
+            "leaderboard_api": "https://c3po.crossfit.com/api/leaderboards/v2/competitions/open/2026/leaderboards",
+            "games_robots": "https://games.crossfit.com/robots.txt",
+            "athlete_page_example": "https://games.crossfit.com/athlete/911088",
+        },
+        "divisions": [dict(row) for row in division_rows],
+        "men_35_39": dict(men_35_39 or {}),
+        "men_35_39_90th_percentile_cutoff": dict(top_90_cutoff or {}),
+        "men_35_39_percentile_buckets": [dict(row) for row in percentile_buckets],
+        "men_35_39_top_countries": [dict(row) for row in top_countries],
+        "men_35_39_top_10_percent_workout_rank_ranges": [dict(row) for row in score_cutoffs],
+        "profile_counts": dict(profile_counts or {}),
+    }
+    (out_dir / "summary.json").write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    (out_dir / "men-35-39-percentile-buckets.svg").write_text(
+        render_bar_chart(
+            "2026 Open Men 35-39 by performance percentile",
+            [(row["bucket"], int(row["athletes"])) for row in percentile_buckets],
+            width=760,
+            height=360,
+        ),
+        encoding="utf-8",
+    )
+    (out_dir / "men-35-39-top-countries.svg").write_text(
+        render_bar_chart(
+            "Top countries in Men 35-39",
+            [(row["country_code"] or "??", int(row["athletes"])) for row in top_countries],
+            width=760,
+            height=420,
+        ),
+        encoding="utf-8",
+    )
+
+
+def render_bar_chart(title: str, values: list[tuple[str, int]], *, width: int, height: int) -> str:
+    margin_left = 120
+    margin_right = 24
+    margin_top = 58
+    margin_bottom = 32
+    bar_gap = 10
+    chart_width = width - margin_left - margin_right
+    chart_height = height - margin_top - margin_bottom
+    max_value = max((value for _, value in values), default=1)
+    bar_height = max(14, (chart_height - bar_gap * max(len(values) - 1, 0)) / max(len(values), 1))
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">',
+        f"<title>{html.escape(title)}</title>",
+        "<desc>Horizontal bar chart generated from the local SQLite artifact.</desc>",
+        '<rect width="100%" height="100%" fill="#f8f8f8"/>',
+        f'<text x="{margin_left}" y="30" font-family="Source Sans Pro, Arial, sans-serif" font-size="22" font-weight="700" fill="#222">{html.escape(title)}</text>',
+    ]
+    for index, (label, value) in enumerate(values):
+        y = margin_top + index * (bar_height + bar_gap)
+        bar_width = chart_width * (value / max_value)
+        parts.append(
+            f'<text x="{margin_left - 12}" y="{y + bar_height * 0.68:.1f}" text-anchor="end" '
+            'font-family="Source Code Pro, monospace" font-size="13" fill="#333">'
+            f"{html.escape(label)}</text>"
+        )
+        parts.append(
+            f'<rect x="{margin_left}" y="{y:.1f}" width="{bar_width:.1f}" height="{bar_height:.1f}" fill="#330033"/>'
+        )
+        parts.append(
+            f'<text x="{margin_left + bar_width + 8:.1f}" y="{y + bar_height * 0.68:.1f}" '
+            'font-family="Source Code Pro, monospace" font-size="13" fill="#333">'
+            f"{value:,}</text>"
+        )
+    parts.append("</svg>")
+    return "\n".join(parts) + "\n"
+
+
+def print_summary(con: sqlite3.Connection) -> None:
+    for row in con.execute(
+        """
+        SELECT d.division_id, d.division_name, d.total_pages, d.total_competitors,
+               COUNT(le.competitor_id) AS scraped_entries
+        FROM divisions d
+        LEFT JOIN leaderboard_entries le
+          ON le.year = d.year
+         AND le.competition_type = d.competition_type
+         AND le.division_id = d.division_id
+        GROUP BY d.year, d.competition_type, d.division_id
+        ORDER BY d.division_id
+        """
+    ):
+        print(
+            f"{row['division_id']:>2} {row['division_name']:<14} "
+            f"pages={row['total_pages'] or 0:<4} "
+            f"competitors={row['total_competitors'] or 0:<7} "
+            f"scraped={row['scraped_entries']}"
+        )
+
+
+def parse_divisions(value: str) -> list[int]:
+    if value == "all":
+        return list(DIVISIONS_2026)
+    divisions = []
+    for part in value.split(","):
+        part = part.strip()
+        if part:
+            divisions.append(int(part))
+    return divisions
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB)
+    parser.add_argument("--year", type=int, default=2026)
+    parser.add_argument("--competition-type", default="open")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    discover_parser = sub.add_parser("discover", help="Fetch page 1 for known divisions and record totals.")
+    discover_parser.add_argument("--sleep", type=float, default=1.0)
+    discover_parser.add_argument("--refresh", action="store_true")
+
+    scrape_parser = sub.add_parser("scrape-leaderboard", help="Fetch and normalize leaderboard pages.")
+    scrape_parser.add_argument("--division", default="18", help="Division id, comma list, or all.")
+    scrape_parser.add_argument("--sort", type=int, default=0)
+    scrape_parser.add_argument("--sleep", type=float, default=1.0)
+    scrape_parser.add_argument("--max-pages", type=int)
+    scrape_parser.add_argument("--refresh", action="store_true")
+
+    profiles_parser = sub.add_parser("scrape-profiles", help="Fetch athlete pages and parse benchmark stats.")
+    profiles_parser.add_argument("--division", type=int, default=18)
+    profiles_parser.add_argument("--limit", type=int)
+    profiles_parser.add_argument("--sleep", type=float, default=3.0)
+    profiles_parser.add_argument("--refresh", action="store_true")
+
+    assets_parser = sub.add_parser("write-summary-assets", help="Write JSON and SVG article assets.")
+    assets_parser.add_argument("--out-dir", type=Path, default=Path("data/crossfit-open"))
+
+    sub.add_parser("summary", help="Print division scrape status.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    con = connect(args.db)
+    set_metadata(con, "source_robots_txt", "https://games.crossfit.com/robots.txt")
+    set_metadata(con, "source_leaderboard_api", "https://c3po.crossfit.com/api/leaderboards/v2/")
+    con.commit()
+
+    if args.command == "discover":
+        discover(
+            con,
+            year=args.year,
+            competition_type=args.competition_type,
+            sleep_seconds=args.sleep,
+            refresh=args.refresh,
+        )
+    elif args.command == "scrape-leaderboard":
+        for division_id in parse_divisions(args.division):
+            scrape_leaderboard(
+                con,
+                year=args.year,
+                competition_type=args.competition_type,
+                division_id=division_id,
+                sort=args.sort,
+                sleep_seconds=args.sleep,
+                max_pages=args.max_pages,
+                refresh=args.refresh,
+            )
+    elif args.command == "scrape-profiles":
+        scrape_profiles(
+            con,
+            year=args.year,
+            competition_type=args.competition_type,
+            division_id=args.division,
+            limit=args.limit,
+            sleep_seconds=args.sleep,
+            refresh=args.refresh,
+        )
+    elif args.command == "write-summary-assets":
+        write_summary_assets(con, args.out_dir)
+    elif args.command == "summary":
+        print_summary(con)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_crossfit_open_article.py
+++ b/scripts/render_crossfit_open_article.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Render the static CrossFit Open dataset article into the published site."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SLUG = "crossfit-open-2026-athlete-dataset"
+TITLE = "Building a 2026 CrossFit Open Athlete Dataset"
+DESCRIPTION = (
+    "A public SQLite artifact and checkpointed scraper for analyzing the 2026 "
+    "CrossFit Open Men 35-39 leaderboard."
+)
+DATE_TEXT = "July 02, 2026"
+DATE_META = "2026-07-02 00:00:00-04:00"
+CATEGORY = "Fitness"
+TAGS = ["crossfit", "fitness", "data", "athlete"]
+
+
+def replace_one(pattern: str, replacement: str, text: str) -> str:
+    new_text, count = re.subn(pattern, replacement, text, count=1, flags=re.DOTALL)
+    if count != 1:
+        raise RuntimeError(f"expected one replacement for {pattern!r}, got {count}")
+    return new_text
+
+
+def article_link() -> str:
+    return f"https://leblancfg.com/{SLUG}"
+
+
+def load_summary() -> dict:
+    return json.loads((ROOT / "data/crossfit-open/summary.json").read_text(encoding="utf-8"))
+
+
+def render_metric(value: object) -> str:
+    if isinstance(value, float):
+        return f"{value:,.1f}"
+    if isinstance(value, int):
+        return f"{value:,}"
+    return html.escape(str(value))
+
+
+def render_article_body(summary: dict) -> str:
+    men = summary["men_35_39"]
+    cutoff = summary["men_35_39_90th_percentile_cutoff"]
+    countries = summary["men_35_39_top_countries"][:8]
+    profile_counts = summary["profile_counts"]
+    score_ranges = summary["men_35_39_top_10_percent_workout_rank_ranges"]
+    generated_at = summary["generated_at"].replace("T", " ").replace("+00:00", " UTC")
+    country_items = "\n".join(
+        f"<li><strong>{html.escape(row['country_code'] or '??')}</strong>: "
+        f"{int(row['athletes']):,} athletes ({html.escape(row['country_name'] or 'Unknown')})</li>"
+        for row in countries
+    )
+    workout_items = "\n".join(
+        f"<li>Workout {html.escape(str(row['ordinal']))}: top-10-percent athlete workout ranks span "
+        f"{int(row['best_rank']):,} to {int(row['worst_rank']):,}.</li>"
+        for row in score_ranges
+    )
+    tag_links = "\n".join(f'<a href="https://leblancfg.com/tag/{tag}.html">{tag}</a>' for tag in TAGS)
+    return f"""
+  <div>
+    <p>I’m competing in the 2027 CrossFit Open in Men 35-39. If the target is 90th percentile worldwide,
+the first useful question is brutally concrete: what does that mean in leaderboard terms?</p>
+
+<p>So I built the beginning of the dataset I wanted to read: a restartable public scrape of the
+CrossFit Games leaderboard API, stored as SQLite, with raw source responses kept beside normalized
+tables. The first complete artifact covers the full 2026 Men 35-39 Open division: <strong>{render_metric(men['entries'])}
+athletes</strong>, <strong>87,513 workout-score rows</strong>, and the API’s published
+<strong>{render_metric(men['entries'])}</strong> competitor field lining up with the normalized row count.</p>
+
+<p><a class="btn" href="/data/crossfit-open/crossfit_open_2026.sqlite">Download the SQLite artifact</a>
+<a class="btn" href="/data/crossfit-open/README.md">Read the data dictionary</a>
+<a class="btn" href="/data/crossfit-open/summary.json">Open summary JSON</a></p>
+
+<h2>The 90th percentile target</h2>
+<p>CrossFit’s current athlete pages did not expose an Open percentile field in the public HTML I checked.
+The dataset derives percentile from rank and field size instead. In Men 35-39 for 2026, the 90th
+percentile cutoff lands at <strong>rank {int(cutoff['max_rank']):,}</strong> out of
+<strong>{render_metric(men['entries'])}</strong>. In plain English: top ten percent meant being inside the
+first <strong>{int(cutoff['athletes']):,}</strong> athletes worldwide.</p>
+
+<p><img alt="Bar chart of Men 35-39 athletes by performance percentile bucket" src="/data/crossfit-open/men-35-39-percentile-buckets.svg"></p>
+
+<p>The athlete at exactly rank 2,918 had an overall score of 11,119. His workout ranks were 6,427,
+1,395, and 3,297. That is useful because it keeps the goal from collapsing into a vague identity
+claim. A 90th percentile Open does not require being elite at everything, but it does require
+surviving one weaker event without letting the total score drift out of range.</p>
+
+<h2>Where the field comes from</h2>
+<p>The field is large enough that country mix matters. The United States dominates the division, but
+Canada still contributes <strong>{int(men['canada_entries']):,}</strong> athletes. The first full scrape found
+these top countries:</p>
+
+<ul>
+{country_items}
+</ul>
+
+<p><img alt="Bar chart of top countries in the 2026 Open Men 35-39 division" src="/data/crossfit-open/men-35-39-top-countries.svg"></p>
+
+<h2>What is in the database</h2>
+<p>The SQLite file includes normalized tables for divisions, athletes, leaderboard entries, workout
+scores, and source fetches. Keeping <code>source_fetches</code> makes the database bigger, but I think it is the
+right tradeoff for a public artifact: readers can inspect exactly what came back from the public API,
+and the scraper can resume without hammering pages it already fetched successfully.</p>
+
+<p>The profile-page path is implemented too, but deliberately sampled rather than fully run. Athlete
+pages are much heavier than leaderboard API pages. The artifact includes <strong>{int(profile_counts['fetched_profiles'])}</strong>
+profile fetches and <strong>{int(profile_counts['benchmark_values'])}</strong> parsed benchmark values to prove
+the parser, while leaving the full profile crawl as an explicit long-running job.</p>
+
+<h2>Useful starter queries</h2>
+<p>Find the 90th percentile boundary:</p>
+<pre><code>select max(overall_rank) as rank_cutoff, count(*) as athletes
+from leaderboard_entries
+where year = 2026
+  and competition_type = 'open'
+  and division_id = 18
+  and performance_percentile &gt;= 90;</code></pre>
+
+<p>Look at the event-rank spread for top-10-percent athletes:</p>
+<pre><code>select ordinal, min(rank) as best_rank, max(rank) as worst_rank
+from workout_scores ws
+join leaderboard_entries le
+  using (year, competition_type, division_id, competitor_id)
+where le.year = 2026
+  and le.competition_type = 'open'
+  and le.division_id = 18
+  and le.performance_percentile &gt;= 90
+group by ordinal
+order by ordinal;</code></pre>
+
+<ul>
+{workout_items}
+</ul>
+
+<h2>Provenance and next step</h2>
+<p>Preflight happened on July 2, 2026. The CrossFit robots file allowed the leaderboard and public
+athlete pages, while disallowing registration, score submission, and athlete-management paths. The
+leaderboard page points at the public <code>c3po.crossfit.com</code> leaderboard API. Athlete pages still expose
+rank tables and self-reported benchmark stats, but I did not find a public Open percentile field.</p>
+
+<p>The full all-division scrape is now a command, not a wish:</p>
+<pre><code>python3 scripts/crossfit_open_dataset.py \\
+  --db data/crossfit-open/crossfit_open_2026.sqlite \\
+  scrape-leaderboard --division all --sleep 1.0</code></pre>
+
+<p>Generated summary timestamp: <code>{html.escape(generated_at)}</code>.</p>
+  </div>
+  <div class="tag-cloud">
+    <p>
+      {tag_links}
+    </p>
+  </div>
+"""
+
+
+def render_article_page(summary: dict) -> None:
+    base = (ROOT / "intensity-pad/index.html").read_text(encoding="utf-8")
+    prefix = base[: base.index('<article class="single">')]
+    suffix = base[base.index("\n<footer>") :]
+    prefix = replace_one(r'<meta name="description" content="[^"]*" />', f'<meta name="description" content="{DESCRIPTION}" />', prefix)
+    prefix = replace_one(r'<meta name="keywords" content="[^"]*">', f'<meta name="keywords" content="{", ".join(TAGS)}">', prefix)
+    prefix = replace_one(r'<meta property="og:title" content="[^"]*"/>', f'<meta property="og:title" content="{TITLE}"/>', prefix)
+    prefix = replace_one(r'<meta property="og:description" content="[^"]*"/>', f'<meta property="og:description" content="{DESCRIPTION}"/>', prefix)
+    prefix = replace_one(r'<meta property="og:url" content="[^"]*"/>', f'<meta property="og:url" content="{article_link()}"/>', prefix)
+    prefix = replace_one(r'<meta property="article:published_time" content="[^"]*"/>', f'<meta property="article:published_time" content="{DATE_META}"/>', prefix)
+    prefix = replace_one(r'<meta property="article:section" content="[^"]*"/>', f'<meta property="article:section" content="{CATEGORY}"/>', prefix)
+    prefix = replace_one(
+        r'(?:\n  <meta property="article:tag" content="[^"]*"/>)+',
+        "".join(f'\n  <meta property="article:tag" content="{tag}"/>' for tag in TAGS),
+        prefix,
+    )
+    prefix = replace_one(r"<title>leblancfg.com &ndash; .*?</title>", f"<title>leblancfg.com &ndash; {TITLE}</title>", prefix)
+    article = f"""<article class="single">
+  <header>
+
+    <h1 id="{SLUG}">{TITLE}</h1>
+    <p>
+      Posted on {DATE_TEXT} in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>
+
+    </p>
+  </header>
+
+{render_article_body(summary)}
+
+</article>
+"""
+    out_dir = ROOT / SLUG
+    out_dir.mkdir(exist_ok=True)
+    page = prefix + article + suffix
+    page = "\n".join(line.rstrip() for line in page.splitlines()) + "\n"
+    (out_dir / "index.html").write_text(page, encoding="utf-8")
+
+
+def insert_once(path: Path, marker: str, snippet: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if article_link() in text:
+        return
+    if marker not in text:
+        raise RuntimeError(f"marker not found in {path}")
+    path.write_text(text.replace(marker, snippet + marker, 1), encoding="utf-8")
+
+
+def update_listing_pages() -> None:
+    article_card = f"""<article>
+  <header>
+    <h2><a href="{article_link()}">{TITLE}</a></h2>
+    <p>
+      Posted on {DATE_TEXT} in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>
+
+
+    </p>
+  </header>
+  <div>
+      <div><p>{DESCRIPTION}</p></div>
+        <br>
+        <a class="btn"
+           href="{article_link()}">
+          Continue reading
+        </a>
+  </div>
+  <hr />
+</article>
+"""
+    archive_entry = f"""          <dt>{DATE_TEXT}</dt>
+
+        <dd>
+          <a href="{article_link()}">{TITLE}</a>
+        </dd>
+"""
+    insert_once(ROOT / "index.html", "<article>\n  <header>", article_card)
+    insert_once(ROOT / "category/fitness.html", "<article>\n  <header>", article_card)
+    insert_once(ROOT / "tag/crossfit.html", "<article>\n  <header>", article_card)
+    insert_once(ROOT / "tag/data.html", "<article>\n  <header>", article_card)
+    insert_once(ROOT / "tag/athlete.html", "<article>\n  <header>", article_card)
+    insert_once(ROOT / "archives.html", "          <dt>June 14, 2026</dt>", archive_entry)
+
+
+def main() -> int:
+    summary = load_summary()
+    render_article_page(summary)
+    update_listing_pages()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tag/athlete.html
+++ b/tag/athlete.html
@@ -164,6 +164,25 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
 
 <article>
   <header>
+    <h2><a href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">Building a 2026 CrossFit Open Athlete Dataset</a></h2>
+    <p>
+      Posted on July 02, 2026 in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>
+
+
+    </p>
+  </header>
+  <div>
+      <div><p>A public SQLite artifact and checkpointed scraper for analyzing the 2026 CrossFit Open Men 35-39 leaderboard.</p></div>
+        <br>
+        <a class="btn"
+           href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">
+          Continue reading
+        </a>
+  </div>
+  <hr />
+</article>
+<article>
+  <header>
     <h2><a href="https://leblancfg.com/crossfit_open_2019_analysis_exercise_statistics">CrossFit Open 2019 Analysis - Exercise Statistics</a></h2>
     <p>
       Posted on June 30, 2019 in <a href="https://leblancfg.com/category/crossfit-python.html">CrossFit, Python</a>

--- a/tag/crossfit.html
+++ b/tag/crossfit.html
@@ -164,6 +164,25 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
 
 <article>
   <header>
+    <h2><a href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">Building a 2026 CrossFit Open Athlete Dataset</a></h2>
+    <p>
+      Posted on July 02, 2026 in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>
+
+
+    </p>
+  </header>
+  <div>
+      <div><p>A public SQLite artifact and checkpointed scraper for analyzing the 2026 CrossFit Open Men 35-39 leaderboard.</p></div>
+        <br>
+        <a class="btn"
+           href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">
+          Continue reading
+        </a>
+  </div>
+  <hr />
+</article>
+<article>
+  <header>
     <h2><a href="https://leblancfg.com/addicted-to-my-power-meter">Addicted to My Power Meter</a></h2>
     <p>
       Posted on May 11, 2025 in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>

--- a/tag/data.html
+++ b/tag/data.html
@@ -164,6 +164,25 @@ rel="me"           href="https://hachyderm.io/@leblancfg"
 
 <article>
   <header>
+    <h2><a href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">Building a 2026 CrossFit Open Athlete Dataset</a></h2>
+    <p>
+      Posted on July 02, 2026 in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>
+
+
+    </p>
+  </header>
+  <div>
+      <div><p>A public SQLite artifact and checkpointed scraper for analyzing the 2026 CrossFit Open Men 35-39 leaderboard.</p></div>
+        <br>
+        <a class="btn"
+           href="https://leblancfg.com/crossfit-open-2026-athlete-dataset">
+          Continue reading
+        </a>
+  </div>
+  <hr />
+</article>
+<article>
+  <header>
     <h2><a href="https://leblancfg.com/addicted-to-my-power-meter">Addicted to My Power Meter</a></h2>
     <p>
       Posted on May 11, 2025 in <a href="https://leblancfg.com/category/fitness.html">Fitness</a>


### PR DESCRIPTION
## Summary
- Add a checkpointed SQLite scraper for public CrossFit Open leaderboard data and optional athlete-profile benchmark parsing.
- Add the public `data/crossfit-open/crossfit_open_2026.sqlite` artifact with the full 2026 Men 35-39 leaderboard: 29,171 athletes and 87,513 workout-score rows.
- Add a static article at `/crossfit-open-2026-athlete-dataset/`, summary JSON, SVG charts, data dictionary, and listing-page links.

## Verification
- `python3 -m py_compile scripts/crossfit_open_dataset.py scripts/render_crossfit_open_article.py`
- `python3 scripts/crossfit_open_dataset.py --db data/crossfit-open/crossfit_open_2026.sqlite summary`
- SQLite `pragma integrity_check` returned `ok`.
- Counts: 584 Men 35-39 leaderboard pages, 29,171 entries, 87,513 workout scores, 25 athlete profile fetches, 165 benchmark stats.
- `git diff --cached --check` before commit.

## Note
GitHub warns that `crossfit_open_2026.sqlite` is 84.97 MB, above the recommended 50 MB but below the 100 MB hard limit. Keeping it as a direct SQLite download matches the public artifact goal.